### PR TITLE
feat(benchmark): implement CRUD endpoints for benchmarks (#6)

### DIFF
--- a/src/main/java/dk/viplev/api/adapter/inbound/rest/BenchmarkApiDelegateImpl.java
+++ b/src/main/java/dk/viplev/api/adapter/inbound/rest/BenchmarkApiDelegateImpl.java
@@ -1,0 +1,47 @@
+package dk.viplev.api.adapter.inbound.rest;
+
+import dk.viplev.api.adapter.inbound.rest.dto.BenchmarkDTO;
+import dk.viplev.api.port.inbound.BenchmarkService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class BenchmarkApiDelegateImpl implements BenchmarkApiDelegate {
+
+    private final BenchmarkService benchmarkService;
+
+    @Override
+    public ResponseEntity<List<BenchmarkDTO>> listBenchmarks(UUID environmentId) {
+        return ResponseEntity.ok(benchmarkService.listBenchmarks(environmentId));
+    }
+
+    @Override
+    public ResponseEntity<BenchmarkDTO> createBenchmark(UUID environmentId, BenchmarkDTO benchmarkDTO) {
+        BenchmarkDTO created = benchmarkService.createBenchmark(environmentId, benchmarkDTO);
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    @Override
+    public ResponseEntity<BenchmarkDTO> getBenchmark(UUID benchmarkId, UUID environmentId) {
+        return ResponseEntity.ok(benchmarkService.getBenchmark(environmentId, benchmarkId));
+    }
+
+    @Override
+    public ResponseEntity<BenchmarkDTO> updateBenchmark(UUID benchmarkId, UUID environmentId, BenchmarkDTO benchmarkDTO) {
+        return ResponseEntity.ok(benchmarkService.updateBenchmark(environmentId, benchmarkId, benchmarkDTO));
+    }
+
+    @Override
+    public ResponseEntity<Void> deleteBenchmark(UUID benchmarkId, UUID environmentId) {
+        benchmarkService.deleteBenchmark(environmentId, benchmarkId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/dk/viplev/api/adapter/inbound/rest/mapper/BenchmarkMapper.java
+++ b/src/main/java/dk/viplev/api/adapter/inbound/rest/mapper/BenchmarkMapper.java
@@ -1,0 +1,11 @@
+package dk.viplev.api.adapter.inbound.rest.mapper;
+
+import dk.viplev.api.adapter.inbound.rest.dto.BenchmarkDTO;
+import dk.viplev.api.domain.model.Benchmark;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface BenchmarkMapper {
+
+    BenchmarkDTO toDto(Benchmark benchmark);
+}

--- a/src/main/java/dk/viplev/api/domain/model/Benchmark.java
+++ b/src/main/java/dk/viplev/api/domain/model/Benchmark.java
@@ -1,0 +1,64 @@
+package dk.viplev.api.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PostLoad;
+import jakarta.persistence.PostPersist;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.domain.Persistable;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "benchmarks")
+@Getter
+@Setter
+public class Benchmark implements Persistable<UUID> {
+
+    @Id
+    private UUID id;
+
+    @Transient
+    private boolean isNew = true;
+
+    @Column(nullable = false)
+    private String name;
+
+    private String description;
+
+    @Column(name = "k6_instructions")
+    private String k6Instructions;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "environment_id", nullable = false)
+    private Environment environment;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Override
+    public boolean isNew() {
+        return isNew;
+    }
+
+    @PostLoad
+    @PostPersist
+    void markNotNew() {
+        this.isNew = false;
+    }
+}

--- a/src/main/java/dk/viplev/api/domain/services/BenchmarkServiceImpl.java
+++ b/src/main/java/dk/viplev/api/domain/services/BenchmarkServiceImpl.java
@@ -1,0 +1,93 @@
+package dk.viplev.api.domain.services;
+
+import dk.viplev.api.adapter.inbound.rest.dto.BenchmarkDTO;
+import dk.viplev.api.adapter.inbound.rest.mapper.BenchmarkMapper;
+import dk.viplev.api.domain.exception.NotFoundException;
+import dk.viplev.api.domain.model.Benchmark;
+import dk.viplev.api.domain.model.Environment;
+import dk.viplev.api.port.inbound.AuthService;
+import dk.viplev.api.port.inbound.BenchmarkService;
+import dk.viplev.api.port.outbound.db.BenchmarkRepository;
+import dk.viplev.api.port.outbound.db.EnvironmentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BenchmarkServiceImpl implements BenchmarkService {
+
+    private final BenchmarkRepository benchmarkRepository;
+    private final EnvironmentRepository environmentRepository;
+    private final AuthService authService;
+    private final BenchmarkMapper benchmarkMapper;
+
+    @Override
+    public List<BenchmarkDTO> listBenchmarks(UUID environmentId) {
+        Environment environment = findEnvironmentByOwner(environmentId);
+        return benchmarkRepository.findByEnvironmentId(environment.getId()).stream()
+                .map(benchmarkMapper::toDto)
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public BenchmarkDTO createBenchmark(UUID environmentId, BenchmarkDTO request) {
+        Environment environment = findEnvironmentByOwner(environmentId);
+
+        Benchmark benchmark = new Benchmark();
+        benchmark.setId(UUID.randomUUID());
+        benchmark.setName(request.getName());
+        benchmark.setDescription(request.getDescription());
+        benchmark.setK6Instructions(request.getK6Instructions());
+        benchmark.setEnvironment(environment);
+
+        Benchmark saved = benchmarkRepository.saveAndFlush(benchmark);
+        return benchmarkMapper.toDto(saved);
+    }
+
+    @Override
+    public BenchmarkDTO getBenchmark(UUID environmentId, UUID benchmarkId) {
+        findEnvironmentByOwner(environmentId);
+        Benchmark benchmark = findBenchmarkByEnvironment(benchmarkId, environmentId);
+        return benchmarkMapper.toDto(benchmark);
+    }
+
+    @Override
+    @Transactional
+    public BenchmarkDTO updateBenchmark(UUID environmentId, UUID benchmarkId, BenchmarkDTO request) {
+        findEnvironmentByOwner(environmentId);
+        Benchmark benchmark = findBenchmarkByEnvironment(benchmarkId, environmentId);
+
+        benchmark.setName(request.getName());
+        benchmark.setDescription(request.getDescription());
+        benchmark.setK6Instructions(request.getK6Instructions());
+
+        Benchmark saved = benchmarkRepository.save(benchmark);
+        return benchmarkMapper.toDto(saved);
+    }
+
+    @Override
+    @Transactional
+    public void deleteBenchmark(UUID environmentId, UUID benchmarkId) {
+        findEnvironmentByOwner(environmentId);
+        Benchmark benchmark = findBenchmarkByEnvironment(benchmarkId, environmentId);
+        benchmarkRepository.delete(benchmark);
+    }
+
+    private Environment findEnvironmentByOwner(UUID environmentId) {
+        UUID ownerId = authService.getAuthenticatedUserId();
+        return environmentRepository.findByIdAndOwnerId(environmentId, ownerId)
+                .orElseThrow(() -> new NotFoundException("Environment not found"));
+    }
+
+    private Benchmark findBenchmarkByEnvironment(UUID benchmarkId, UUID environmentId) {
+        return benchmarkRepository.findByIdAndEnvironmentId(benchmarkId, environmentId)
+                .orElseThrow(() -> new NotFoundException("Benchmark not found"));
+    }
+}

--- a/src/main/java/dk/viplev/api/port/inbound/BenchmarkService.java
+++ b/src/main/java/dk/viplev/api/port/inbound/BenchmarkService.java
@@ -1,0 +1,19 @@
+package dk.viplev.api.port.inbound;
+
+import dk.viplev.api.adapter.inbound.rest.dto.BenchmarkDTO;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface BenchmarkService {
+
+    List<BenchmarkDTO> listBenchmarks(UUID environmentId);
+
+    BenchmarkDTO createBenchmark(UUID environmentId, BenchmarkDTO request);
+
+    BenchmarkDTO getBenchmark(UUID environmentId, UUID benchmarkId);
+
+    BenchmarkDTO updateBenchmark(UUID environmentId, UUID benchmarkId, BenchmarkDTO request);
+
+    void deleteBenchmark(UUID environmentId, UUID benchmarkId);
+}

--- a/src/main/java/dk/viplev/api/port/outbound/db/BenchmarkRepository.java
+++ b/src/main/java/dk/viplev/api/port/outbound/db/BenchmarkRepository.java
@@ -1,0 +1,17 @@
+package dk.viplev.api.port.outbound.db;
+
+import dk.viplev.api.domain.model.Benchmark;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface BenchmarkRepository extends JpaRepository<Benchmark, UUID> {
+
+    List<Benchmark> findByEnvironmentId(UUID environmentId);
+
+    Optional<Benchmark> findByIdAndEnvironmentId(UUID id, UUID environmentId);
+}

--- a/src/test/java/dk/viplev/api/adapter/inbound/rest/BenchmarkApiDelegateImplIT.java
+++ b/src/test/java/dk/viplev/api/adapter/inbound/rest/BenchmarkApiDelegateImplIT.java
@@ -1,0 +1,207 @@
+package dk.viplev.api.adapter.inbound.rest;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class BenchmarkApiDelegateImplIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private String user1Token;
+    private String user2Token;
+    private String user1EnvironmentId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        user1Token = loginAndGetToken("user1@viplev.dk", "password");
+        user2Token = loginAndGetToken("user2@viplev.dk", "password");
+        user1EnvironmentId = createEnvironment(user1Token, "Benchmark Test Env", "docker");
+    }
+
+    private String loginAndGetToken(String email, String password) throws Exception {
+        String loginJson = objectMapper.writeValueAsString(
+                java.util.Map.of("email", email, "password", password));
+
+        MvcResult result = mockMvc.perform(post("/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(loginJson))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode node = objectMapper.readTree(result.getResponse().getContentAsString());
+        return node.get("token").asText();
+    }
+
+    private String createEnvironment(String token, String name, String type) throws Exception {
+        String json = objectMapper.writeValueAsString(
+                java.util.Map.of("name", name, "type", type));
+
+        MvcResult result = mockMvc.perform(post("/v1/environments")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        return objectMapper.readTree(result.getResponse().getContentAsString())
+                .get("id").asText();
+    }
+
+    private String benchmarkUrl(String environmentId) {
+        return "/v1/environments/" + environmentId + "/benchmarks";
+    }
+
+    private String benchmarkUrl(String environmentId, String benchmarkId) {
+        return "/v1/environments/" + environmentId + "/benchmarks/" + benchmarkId;
+    }
+
+    private String benchmarkJson(String name, String description, String k6Instructions) throws Exception {
+        return objectMapper.writeValueAsString(
+                java.util.Map.of("name", name, "description", description, "k6Instructions", k6Instructions));
+    }
+
+    @Test
+    void shouldPerformFullCrudFlow() throws Exception {
+        // Create
+        MvcResult createResult = mockMvc.perform(post(benchmarkUrl(user1EnvironmentId))
+                        .header("Authorization", "Bearer " + user1Token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(benchmarkJson("Load Test", "Test description", "import http from 'k6/http';")))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("Load Test"))
+                .andExpect(jsonPath("$.description").value("Test description"))
+                .andExpect(jsonPath("$.k6Instructions").value("import http from 'k6/http';"))
+                .andExpect(jsonPath("$.id").isNotEmpty())
+                .andExpect(jsonPath("$.createdAt").isNotEmpty())
+                .andReturn();
+
+        String benchmarkId = objectMapper.readTree(createResult.getResponse().getContentAsString())
+                .get("id").asText();
+
+        // List
+        mockMvc.perform(get(benchmarkUrl(user1EnvironmentId))
+                        .header("Authorization", "Bearer " + user1Token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[?(@.name == 'Load Test')]").exists());
+
+        // Get
+        mockMvc.perform(get(benchmarkUrl(user1EnvironmentId, benchmarkId))
+                        .header("Authorization", "Bearer " + user1Token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Load Test"))
+                .andExpect(jsonPath("$.id").value(benchmarkId));
+
+        // Update
+        mockMvc.perform(put(benchmarkUrl(user1EnvironmentId, benchmarkId))
+                        .header("Authorization", "Bearer " + user1Token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(benchmarkJson("Updated Test", "Updated desc", "export default function() {}")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Updated Test"))
+                .andExpect(jsonPath("$.description").value("Updated desc"))
+                .andExpect(jsonPath("$.k6Instructions").value("export default function() {}"));
+
+        // Delete
+        mockMvc.perform(delete(benchmarkUrl(user1EnvironmentId, benchmarkId))
+                        .header("Authorization", "Bearer " + user1Token))
+                .andExpect(status().isNoContent());
+
+        // Verify gone
+        mockMvc.perform(get(benchmarkUrl(user1EnvironmentId, benchmarkId))
+                        .header("Authorization", "Bearer " + user1Token))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldEnforceOwnership() throws Exception {
+        // User1 creates benchmark
+        MvcResult createResult = mockMvc.perform(post(benchmarkUrl(user1EnvironmentId))
+                        .header("Authorization", "Bearer " + user1Token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(benchmarkJson("Private Benchmark", "desc", "script")))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        String benchmarkId = objectMapper.readTree(createResult.getResponse().getContentAsString())
+                .get("id").asText();
+
+        // User2 cannot list benchmarks in user1's environment
+        mockMvc.perform(get(benchmarkUrl(user1EnvironmentId))
+                        .header("Authorization", "Bearer " + user2Token))
+                .andExpect(status().isNotFound());
+
+        // User2 cannot get the benchmark
+        mockMvc.perform(get(benchmarkUrl(user1EnvironmentId, benchmarkId))
+                        .header("Authorization", "Bearer " + user2Token))
+                .andExpect(status().isNotFound());
+
+        // User2 cannot update the benchmark
+        mockMvc.perform(put(benchmarkUrl(user1EnvironmentId, benchmarkId))
+                        .header("Authorization", "Bearer " + user2Token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(benchmarkJson("Hacked", "hacked", "hacked")))
+                .andExpect(status().isNotFound());
+
+        // User2 cannot delete the benchmark
+        mockMvc.perform(delete(benchmarkUrl(user1EnvironmentId, benchmarkId))
+                        .header("Authorization", "Bearer " + user2Token))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldReturn404ForNonExistentBenchmark() throws Exception {
+        mockMvc.perform(get(benchmarkUrl(user1EnvironmentId, "00000000-0000-0000-0000-000000000000"))
+                        .header("Authorization", "Bearer " + user1Token))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldReturn404ForBenchmarkUnderWrongEnvironment() throws Exception {
+        // Create benchmark in user1's environment
+        MvcResult createResult = mockMvc.perform(post(benchmarkUrl(user1EnvironmentId))
+                        .header("Authorization", "Bearer " + user1Token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(benchmarkJson("Env1 Benchmark", "desc", "script")))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        String benchmarkId = objectMapper.readTree(createResult.getResponse().getContentAsString())
+                .get("id").asText();
+
+        // Create a second environment for user1
+        String env2Id = createEnvironment(user1Token, "Second Env", "docker");
+
+        // Try to get benchmark under wrong environment
+        mockMvc.perform(get(benchmarkUrl(env2Id, benchmarkId))
+                        .header("Authorization", "Bearer " + user1Token))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldReturn401WithoutToken() throws Exception {
+        mockMvc.perform(get(benchmarkUrl(user1EnvironmentId)))
+                .andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
## Summary
- Add Benchmark domain model (JPA entity) with `@ManyToOne` relationship to Environment
- Implement full CRUD: repository, service interface/impl, MapStruct mapper, and REST delegate
- Ownership validation ensures users can only access benchmarks in their own environments
- Integration tests covering CRUD flow, ownership enforcement, wrong-environment 404, and auth required

## Test plan
- [x] `./gradlew build` passes
- [x] Full CRUD flow test (create → list → get → update → delete → verify gone)
- [x] Ownership test: user2 cannot access user1's benchmarks (404)
- [x] Benchmark under wrong environment returns 404
- [x] Unauthenticated request returns 401