### PR TITLE
feat(agent): implement update benchmark run status endpoint (#10)

### DIFF
--- a/src/main/java/dk/viplev/api/adapter/inbound/rest/AgentApiDelegateImpl.java
+++ b/src/main/java/dk/viplev/api/adapter/inbound/rest/AgentApiDelegateImpl.java
@@ -1,6 +1,9 @@
 package dk.viplev.api.adapter.inbound.rest;
 
+import dk.viplev.api.adapter.inbound.rest.dto.BenchmarkRunDTO;
+import dk.viplev.api.adapter.inbound.rest.dto.BenchmarkRunStatusUpdateDTO;
 import dk.viplev.api.adapter.inbound.rest.dto.ServiceRegistrationDTO;
+import dk.viplev.api.port.inbound.AgentService;
 import dk.viplev.api.port.inbound.ServiceService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,10 +19,17 @@ import java.util.UUID;
 public class AgentApiDelegateImpl implements AgentApiDelegate {
 
     private final ServiceService serviceService;
+    private final AgentService agentService;
 
     @Override
     public ResponseEntity<Void> registerServices(UUID environmentId, ServiceRegistrationDTO serviceRegistrationDTO) {
         serviceService.registerServices(environmentId, serviceRegistrationDTO);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @Override
+    public ResponseEntity<BenchmarkRunDTO> updateBenchmarkRunStatus(UUID environmentId, UUID benchmarkId, UUID runId, BenchmarkRunStatusUpdateDTO benchmarkRunStatusUpdateDTO) {
+        BenchmarkRunDTO dto = agentService.updateBenchmarkRunStatus(environmentId, benchmarkId, runId, benchmarkRunStatusUpdateDTO);
+        return ResponseEntity.ok(dto);
     }
 }

--- a/src/main/java/dk/viplev/api/domain/services/AgentServiceImpl.java
+++ b/src/main/java/dk/viplev/api/domain/services/AgentServiceImpl.java
@@ -1,0 +1,90 @@
+package dk.viplev.api.domain.services;
+
+import dk.viplev.api.adapter.inbound.rest.dto.BenchmarkRunDTO;
+import dk.viplev.api.adapter.inbound.rest.dto.BenchmarkRunStatusUpdateDTO;
+import dk.viplev.api.adapter.inbound.rest.mapper.BenchmarkRunMapper;
+import dk.viplev.api.domain.exception.BadRequestException;
+import dk.viplev.api.domain.exception.NotFoundException;
+import dk.viplev.api.domain.model.BenchmarkRun;
+import dk.viplev.api.domain.model.BenchmarkRunStatus;
+import dk.viplev.api.port.inbound.AgentService;
+import dk.viplev.api.port.inbound.AuthService;
+import dk.viplev.api.port.outbound.db.BenchmarkRepository;
+import dk.viplev.api.port.outbound.db.BenchmarkRunRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class AgentServiceImpl implements AgentService {
+
+    private static final Map<BenchmarkRunStatus, Set<BenchmarkRunStatus>> VALID_TRANSITIONS = Map.of(
+            BenchmarkRunStatus.PENDING_START, Set.of(BenchmarkRunStatus.STARTED, BenchmarkRunStatus.FAILED),
+            BenchmarkRunStatus.STARTED, Set.of(BenchmarkRunStatus.FINISHED, BenchmarkRunStatus.FAILED),
+            BenchmarkRunStatus.PENDING_STOP, Set.of(BenchmarkRunStatus.STOPPED, BenchmarkRunStatus.FAILED)
+    );
+
+    private final BenchmarkRunRepository benchmarkRunRepository;
+    private final BenchmarkRepository benchmarkRepository;
+    private final AuthService authService;
+    private final BenchmarkRunMapper benchmarkRunMapper;
+
+    @Override
+    @Transactional
+    public BenchmarkRunDTO updateBenchmarkRunStatus(UUID environmentId, UUID benchmarkId, UUID runId, BenchmarkRunStatusUpdateDTO dto) {
+        validateEnvironmentAccess(environmentId);
+
+        benchmarkRepository.findByIdAndEnvironmentId(benchmarkId, environmentId)
+                .orElseThrow(() -> new NotFoundException("Benchmark not found"));
+
+        BenchmarkRun run = benchmarkRunRepository.findByIdAndBenchmarkId(runId, benchmarkId)
+                .orElseThrow(() -> new NotFoundException("Benchmark run not found"));
+
+        BenchmarkRunStatus newStatus = BenchmarkRunStatus.valueOf(dto.getStatus().name());
+
+        validateTransition(run.getStatus(), newStatus);
+        validateStatusReason(newStatus, dto.getStatusReason());
+
+        run.setStatus(newStatus);
+        run.setStatusReason(dto.getStatusReason());
+
+        if (newStatus == BenchmarkRunStatus.STARTED) {
+            run.setStartedAt(LocalDateTime.now());
+        }
+        if (newStatus == BenchmarkRunStatus.FINISHED || newStatus == BenchmarkRunStatus.STOPPED || newStatus == BenchmarkRunStatus.FAILED) {
+            run.setFinishedAt(LocalDateTime.now());
+        }
+
+        benchmarkRunRepository.save(run);
+
+        return benchmarkRunMapper.toDto(run);
+    }
+
+    private void validateEnvironmentAccess(UUID environmentId) {
+        UUID tokenEnvironmentId = authService.getAuthenticatedEnvironmentId();
+        if (!environmentId.equals(tokenEnvironmentId)) {
+            throw new NotFoundException("Environment not found");
+        }
+    }
+
+    private void validateTransition(BenchmarkRunStatus currentStatus, BenchmarkRunStatus newStatus) {
+        Set<BenchmarkRunStatus> allowedTransitions = VALID_TRANSITIONS.get(currentStatus);
+        if (allowedTransitions == null || !allowedTransitions.contains(newStatus)) {
+            throw new BadRequestException("Invalid status transition",
+                    "Cannot transition from " + currentStatus + " to " + newStatus);
+        }
+    }
+
+    private void validateStatusReason(BenchmarkRunStatus newStatus, String statusReason) {
+        if (newStatus == BenchmarkRunStatus.FAILED && (statusReason == null || statusReason.isBlank())) {
+            throw new BadRequestException("Status reason required",
+                    "statusReason is required when status is FAILED");
+        }
+    }
+}

--- a/src/main/java/dk/viplev/api/port/inbound/AgentService.java
+++ b/src/main/java/dk/viplev/api/port/inbound/AgentService.java
@@ -1,0 +1,11 @@
+package dk.viplev.api.port.inbound;
+
+import dk.viplev.api.adapter.inbound.rest.dto.BenchmarkRunDTO;
+import dk.viplev.api.adapter.inbound.rest.dto.BenchmarkRunStatusUpdateDTO;
+
+import java.util.UUID;
+
+public interface AgentService {
+
+    BenchmarkRunDTO updateBenchmarkRunStatus(UUID environmentId, UUID benchmarkId, UUID runId, BenchmarkRunStatusUpdateDTO dto);
+}

--- a/src/test/java/dk/viplev/api/adapter/inbound/rest/AgentUpdateRunStatusIT.java
+++ b/src/test/java/dk/viplev/api/adapter/inbound/rest/AgentUpdateRunStatusIT.java
@@ -1,0 +1,316 @@
+package dk.viplev.api.adapter.inbound.rest;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import dk.viplev.api.domain.model.Benchmark;
+import dk.viplev.api.domain.model.BenchmarkRun;
+import dk.viplev.api.domain.model.BenchmarkRunStatus;
+import dk.viplev.api.domain.model.User;
+import dk.viplev.api.port.outbound.db.BenchmarkRepository;
+import dk.viplev.api.port.outbound.db.BenchmarkRunRepository;
+import dk.viplev.api.port.outbound.db.UserRepository;
+
+import java.util.Map;
+import java.util.UUID;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AgentUpdateRunStatusIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private BenchmarkRunRepository benchmarkRunRepository;
+
+    @Autowired
+    private BenchmarkRepository benchmarkRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private String user1Token;
+    private String environmentId;
+    private String environmentToken;
+    private String benchmarkId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        user1Token = loginAndGetToken("user1@viplev.dk", "password");
+
+        JsonNode env = createEnvironmentAndGetResponse("Agent Status Test Env", user1Token);
+        environmentId = env.get("id").asText();
+        environmentToken = env.get("token").asText();
+
+        benchmarkId = createBenchmark(user1Token, environmentId, "Agent Status Benchmark");
+    }
+
+    private String loginAndGetToken(String email, String password) throws Exception {
+        String loginJson = objectMapper.writeValueAsString(
+                Map.of("email", email, "password", password));
+
+        MvcResult result = mockMvc.perform(post("/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(loginJson))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode node = objectMapper.readTree(result.getResponse().getContentAsString());
+        return node.get("token").asText();
+    }
+
+    private JsonNode createEnvironmentAndGetResponse(String name, String token) throws Exception {
+        String json = objectMapper.writeValueAsString(Map.of("name", name, "type", "docker"));
+        MvcResult result = mockMvc.perform(post("/v1/environments")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString());
+    }
+
+    private String createBenchmark(String token, String environmentId, String name) throws Exception {
+        String json = objectMapper.writeValueAsString(Map.of("name", name));
+
+        MvcResult result = mockMvc.perform(post("/v1/environments/" + environmentId + "/benchmarks")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        return objectMapper.readTree(result.getResponse().getContentAsString())
+                .get("id").asText();
+    }
+
+    private UUID createRunDirectly(UUID benchmarkUuid, String userEmail, BenchmarkRunStatus status) {
+        Benchmark benchmark = benchmarkRepository.findById(benchmarkUuid).orElseThrow();
+        User user = userRepository.findByEmail(userEmail).orElseThrow();
+
+        BenchmarkRun run = new BenchmarkRun();
+        run.setBenchmark(benchmark);
+        run.setStartedByUser(user);
+        run.setStatus(status);
+        return benchmarkRunRepository.saveAndFlush(run).getId();
+    }
+
+    private String statusUrl(String environmentId, String benchmarkId, String runId) {
+        return "/v1/environments/" + environmentId + "/benchmarks/" + benchmarkId + "/runs/" + runId + "/status";
+    }
+
+    private String statusBody(String status) throws Exception {
+        return objectMapper.writeValueAsString(Map.of("status", status));
+    }
+
+    private String statusBodyWithReason(String status, String reason) throws Exception {
+        return objectMapper.writeValueAsString(Map.of("status", status, "statusReason", reason));
+    }
+
+    // --- Valid transitions ---
+
+    @Test
+    void shouldTransitionFromPendingStartToStarted() throws Exception {
+        UUID runId = createRunDirectly(UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.PENDING_START);
+
+        mockMvc.perform(post(statusUrl(environmentId, benchmarkId, runId.toString()))
+                        .header("Authorization", "Bearer " + environmentToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(statusBody("STARTED")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("STARTED"))
+                .andExpect(jsonPath("$.startedAt").isNotEmpty());
+    }
+
+    @Test
+    void shouldTransitionFromStartedToFinished() throws Exception {
+        UUID runId = createRunDirectly(UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.STARTED);
+
+        mockMvc.perform(post(statusUrl(environmentId, benchmarkId, runId.toString()))
+                        .header("Authorization", "Bearer " + environmentToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(statusBody("FINISHED")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("FINISHED"))
+                .andExpect(jsonPath("$.finishedAt").isNotEmpty());
+    }
+
+    @Test
+    void shouldTransitionFromStartedToFailed() throws Exception {
+        UUID runId = createRunDirectly(UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.STARTED);
+
+        mockMvc.perform(post(statusUrl(environmentId, benchmarkId, runId.toString()))
+                        .header("Authorization", "Bearer " + environmentToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(statusBodyWithReason("FAILED", "K6 script error")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("FAILED"))
+                .andExpect(jsonPath("$.statusReason").value("K6 script error"))
+                .andExpect(jsonPath("$.finishedAt").isNotEmpty());
+    }
+
+    @Test
+    void shouldTransitionFromPendingStopToStopped() throws Exception {
+        UUID runId = createRunDirectly(UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.PENDING_STOP);
+
+        mockMvc.perform(post(statusUrl(environmentId, benchmarkId, runId.toString()))
+                        .header("Authorization", "Bearer " + environmentToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(statusBody("STOPPED")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("STOPPED"))
+                .andExpect(jsonPath("$.finishedAt").isNotEmpty());
+    }
+
+    @Test
+    void shouldTransitionFromPendingStopToFailed() throws Exception {
+        UUID runId = createRunDirectly(UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.PENDING_STOP);
+
+        mockMvc.perform(post(statusUrl(environmentId, benchmarkId, runId.toString()))
+                        .header("Authorization", "Bearer " + environmentToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(statusBodyWithReason("FAILED", "Agent crash")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("FAILED"))
+                .andExpect(jsonPath("$.statusReason").value("Agent crash"));
+    }
+
+    @Test
+    void shouldTransitionFromPendingStartToFailed() throws Exception {
+        UUID runId = createRunDirectly(UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.PENDING_START);
+
+        mockMvc.perform(post(statusUrl(environmentId, benchmarkId, runId.toString()))
+                        .header("Authorization", "Bearer " + environmentToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(statusBodyWithReason("FAILED", "Could not start K6")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("FAILED"));
+    }
+
+    // --- Invalid transitions ---
+
+    @Test
+    void shouldReturn400ForInvalidTransitionPendingStartToFinished() throws Exception {
+        UUID runId = createRunDirectly(UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.PENDING_START);
+
+        mockMvc.perform(post(statusUrl(environmentId, benchmarkId, runId.toString()))
+                        .header("Authorization", "Bearer " + environmentToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(statusBody("FINISHED")))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldReturn400ForInvalidTransitionStartedToStopped() throws Exception {
+        UUID runId = createRunDirectly(UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.STARTED);
+
+        mockMvc.perform(post(statusUrl(environmentId, benchmarkId, runId.toString()))
+                        .header("Authorization", "Bearer " + environmentToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(statusBody("STOPPED")))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldReturn400ForTransitionFromTerminalStateStopped() throws Exception {
+        UUID runId = createRunDirectly(UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.STOPPED);
+
+        mockMvc.perform(post(statusUrl(environmentId, benchmarkId, runId.toString()))
+                        .header("Authorization", "Bearer " + environmentToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(statusBody("STARTED")))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldReturn400ForTransitionFromTerminalStateFailed() throws Exception {
+        UUID runId = createRunDirectly(UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.FAILED);
+
+        mockMvc.perform(post(statusUrl(environmentId, benchmarkId, runId.toString()))
+                        .header("Authorization", "Bearer " + environmentToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(statusBody("STARTED")))
+                .andExpect(status().isBadRequest());
+    }
+
+    // --- statusReason validation ---
+
+    @Test
+    void shouldReturn400WhenFailedWithoutStatusReason() throws Exception {
+        UUID runId = createRunDirectly(UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.STARTED);
+
+        mockMvc.perform(post(statusUrl(environmentId, benchmarkId, runId.toString()))
+                        .header("Authorization", "Bearer " + environmentToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(statusBody("FAILED")))
+                .andExpect(status().isBadRequest());
+    }
+
+    // --- Environment access ---
+
+    @Test
+    void shouldReturn404WhenAgentAccessesOtherEnvironment() throws Exception {
+        String user2Token = loginAndGetToken("user2@viplev.dk", "password");
+        JsonNode env2 = createEnvironmentAndGetResponse("Other Agent Env", user2Token);
+        String env2Id = env2.get("id").asText();
+        String benchmark2Id = createBenchmark(user2Token, env2Id, "Other Benchmark");
+
+        UUID runId = createRunDirectly(UUID.fromString(benchmark2Id), "user2@viplev.dk", BenchmarkRunStatus.PENDING_START);
+
+        // Use env1's token to access env2's run
+        mockMvc.perform(post(statusUrl(env2Id, benchmark2Id, runId.toString()))
+                        .header("Authorization", "Bearer " + environmentToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(statusBody("STARTED")))
+                .andExpect(status().isNotFound());
+    }
+
+    // --- Not found ---
+
+    @Test
+    void shouldReturn404ForNonExistentRun() throws Exception {
+        mockMvc.perform(post(statusUrl(environmentId, benchmarkId, UUID.randomUUID().toString()))
+                        .header("Authorization", "Bearer " + environmentToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(statusBody("STARTED")))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldReturn404ForNonExistentBenchmark() throws Exception {
+        mockMvc.perform(post(statusUrl(environmentId, UUID.randomUUID().toString(), UUID.randomUUID().toString()))
+                        .header("Authorization", "Bearer " + environmentToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(statusBody("STARTED")))
+                .andExpect(status().isNotFound());
+    }
+
+    // --- Auth ---
+
+    @Test
+    void shouldReturn401WithoutToken() throws Exception {
+        UUID runId = createRunDirectly(UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.PENDING_START);
+
+        mockMvc.perform(post(statusUrl(environmentId, benchmarkId, runId.toString()))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(statusBody("STARTED")))
+                .andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
Closes #10

## Summary
- Implement `POST /v1/environments/{environmentId}/benchmarks/{benchmarkId}/runs/{runId}/status` for agent status updates
- Validated state transitions: `PENDING_START→STARTED/FAILED`, `STARTED→FINISHED/FAILED`, `PENDING_STOP→STOPPED/FAILED`
- `statusReason` required when status is `FAILED`, otherwise 400
- Automatic timestamp management: `startedAt` on STARTED, `finishedAt` on FINISHED/STOPPED/FAILED
- Environment token validation prevents cross-environment access

## Test plan
- [x] All valid transitions (PENDING_START→STARTED, STARTED→FINISHED, STARTED→FAILED, PENDING_STOP→STOPPED, PENDING_STOP→FAILED, PENDING_START→FAILED)
- [x] Invalid transitions return 400 (PENDING_START→FINISHED, STARTED→STOPPED, terminal states)
- [x] FAILED without statusReason → 400
- [x] Timestamps set correctly (startedAt, finishedAt)
- [x] Agent cannot access other environment's runs → 404
- [x] Non-existent run/benchmark → 404
- [x] No token → 401
- [x] All existing tests still pass