### PR TITLE
feat(agent): implement message queue polling endpoint

### DIFF
--- a/src/main/java/dk/viplev/api/adapter/inbound/rest/AgentApiDelegateImpl.java
+++ b/src/main/java/dk/viplev/api/adapter/inbound/rest/AgentApiDelegateImpl.java
@@ -2,6 +2,7 @@ package dk.viplev.api.adapter.inbound.rest;
 
 import dk.viplev.api.adapter.inbound.rest.dto.BenchmarkRunDTO;
 import dk.viplev.api.adapter.inbound.rest.dto.BenchmarkRunStatusUpdateDTO;
+import dk.viplev.api.adapter.inbound.rest.dto.MessageDTO;
 import dk.viplev.api.adapter.inbound.rest.dto.MetricPerformanceDTO;
 import dk.viplev.api.adapter.inbound.rest.dto.MetricResourceDTO;
 import dk.viplev.api.adapter.inbound.rest.dto.ServiceRegistrationDTO;
@@ -13,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.UUID;
 
 @Component
@@ -22,6 +24,11 @@ public class AgentApiDelegateImpl implements AgentApiDelegate {
 
     private final ServiceService serviceService;
     private final AgentService agentService;
+
+    @Override
+    public ResponseEntity<List<MessageDTO>> listMessages(UUID environmentId) {
+        return ResponseEntity.ok(agentService.listMessages(environmentId));
+    }
 
     @Override
     public ResponseEntity<Void> registerServices(UUID environmentId, ServiceRegistrationDTO serviceRegistrationDTO) {

--- a/src/main/java/dk/viplev/api/adapter/inbound/rest/mapper/MessageMapper.java
+++ b/src/main/java/dk/viplev/api/adapter/inbound/rest/mapper/MessageMapper.java
@@ -1,0 +1,26 @@
+package dk.viplev.api.adapter.inbound.rest.mapper;
+
+import dk.viplev.api.adapter.inbound.rest.dto.MessageDTO;
+import dk.viplev.api.domain.model.BenchmarkRun;
+import dk.viplev.api.domain.model.BenchmarkRunStatus;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+
+@Mapper(componentModel = "spring")
+public interface MessageMapper {
+
+    @Mapping(source = "benchmark.id", target = "benchmarkId")
+    @Mapping(source = "id", target = "runId")
+    @Mapping(source = "status", target = "messageType", qualifiedByName = "toMessageType")
+    MessageDTO toDto(BenchmarkRun benchmarkRun);
+
+    @Named("toMessageType")
+    default MessageDTO.MessageTypeEnum toMessageType(BenchmarkRunStatus status) {
+        return switch (status) {
+            case PENDING_START -> MessageDTO.MessageTypeEnum.PENDING_START;
+            case PENDING_STOP -> MessageDTO.MessageTypeEnum.PENDING_STOP;
+            default -> throw new IllegalArgumentException("Unsupported message status: " + status);
+        };
+    }
+}

--- a/src/main/java/dk/viplev/api/domain/services/AgentServiceImpl.java
+++ b/src/main/java/dk/viplev/api/domain/services/AgentServiceImpl.java
@@ -2,6 +2,7 @@ package dk.viplev.api.domain.services;
 
 import dk.viplev.api.adapter.inbound.rest.dto.BenchmarkRunDTO;
 import dk.viplev.api.adapter.inbound.rest.dto.BenchmarkRunStatusUpdateDTO;
+import dk.viplev.api.adapter.inbound.rest.dto.MessageDTO;
 import dk.viplev.api.adapter.inbound.rest.dto.MetricK6HttpDTO;
 import dk.viplev.api.adapter.inbound.rest.dto.MetricK6VusDTO;
 import dk.viplev.api.adapter.inbound.rest.dto.MetricPerformanceDTO;
@@ -10,10 +11,12 @@ import dk.viplev.api.adapter.inbound.rest.dto.MetricResourceDTO;
 import dk.viplev.api.adapter.inbound.rest.dto.MetricResourceNodeDTO;
 import dk.viplev.api.adapter.inbound.rest.dto.MetricResourceServiceDTO;
 import dk.viplev.api.adapter.inbound.rest.mapper.BenchmarkRunMapper;
+import dk.viplev.api.adapter.inbound.rest.mapper.MessageMapper;
 import dk.viplev.api.domain.exception.BadRequestException;
 import dk.viplev.api.domain.exception.NotFoundException;
 import dk.viplev.api.domain.model.BenchmarkRun;
 import dk.viplev.api.domain.model.BenchmarkRunStatus;
+import dk.viplev.api.domain.model.Environment;
 import dk.viplev.api.domain.model.Host;
 import dk.viplev.api.domain.model.MetricK6Http;
 import dk.viplev.api.domain.model.MetricK6Vus;
@@ -24,6 +27,7 @@ import dk.viplev.api.port.inbound.AgentService;
 import dk.viplev.api.port.inbound.AuthService;
 import dk.viplev.api.port.outbound.db.BenchmarkRepository;
 import dk.viplev.api.port.outbound.db.BenchmarkRunRepository;
+import dk.viplev.api.port.outbound.db.EnvironmentRepository;
 import dk.viplev.api.port.outbound.db.HostRepository;
 import dk.viplev.api.port.outbound.db.MetricK6HttpRepository;
 import dk.viplev.api.port.outbound.db.MetricK6VusRepository;
@@ -60,8 +64,31 @@ public class AgentServiceImpl implements AgentService {
     private final MetricResourceServiceRepository metricResourceServiceRepository;
     private final MetricK6HttpRepository metricK6HttpRepository;
     private final MetricK6VusRepository metricK6VusRepository;
+    private final EnvironmentRepository environmentRepository;
     private final AuthService authService;
     private final BenchmarkRunMapper benchmarkRunMapper;
+    private final MessageMapper messageMapper;
+
+    @Override
+    @Transactional
+    public List<MessageDTO> listMessages(UUID environmentId) {
+        validateEnvironmentAccess(environmentId);
+
+        Environment environment = environmentRepository.findById(environmentId)
+                .orElseThrow(() -> new NotFoundException("Environment not found"));
+        environment.setAgentLastSeenAt(LocalDateTime.now());
+        environmentRepository.save(environment);
+
+        return benchmarkRunRepository
+                .findFirstByBenchmarkEnvironmentIdAndStatusOrderByCreatedAtAsc(environmentId, BenchmarkRunStatus.PENDING_STOP)
+                .map(messageMapper::toDto)
+                .map(List::of)
+                .orElseGet(() -> benchmarkRunRepository
+                        .findFirstByBenchmarkEnvironmentIdAndStatusOrderByCreatedAtAsc(environmentId, BenchmarkRunStatus.PENDING_START)
+                        .map(messageMapper::toDto)
+                        .map(List::of)
+                        .orElseGet(List::of));
+    }
 
     @Override
     @Transactional

--- a/src/main/java/dk/viplev/api/port/inbound/AgentService.java
+++ b/src/main/java/dk/viplev/api/port/inbound/AgentService.java
@@ -2,12 +2,16 @@ package dk.viplev.api.port.inbound;
 
 import dk.viplev.api.adapter.inbound.rest.dto.BenchmarkRunDTO;
 import dk.viplev.api.adapter.inbound.rest.dto.BenchmarkRunStatusUpdateDTO;
+import dk.viplev.api.adapter.inbound.rest.dto.MessageDTO;
 import dk.viplev.api.adapter.inbound.rest.dto.MetricPerformanceDTO;
 import dk.viplev.api.adapter.inbound.rest.dto.MetricResourceDTO;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface AgentService {
+
+    List<MessageDTO> listMessages(UUID environmentId);
 
     BenchmarkRunDTO updateBenchmarkRunStatus(UUID environmentId, UUID benchmarkId, UUID runId, BenchmarkRunStatusUpdateDTO dto);
 

--- a/src/main/java/dk/viplev/api/port/outbound/db/BenchmarkRunRepository.java
+++ b/src/main/java/dk/viplev/api/port/outbound/db/BenchmarkRunRepository.java
@@ -23,6 +23,8 @@ public interface BenchmarkRunRepository extends JpaRepository<BenchmarkRun, UUID
 
     boolean existsByBenchmarkIdAndStatusIn(UUID benchmarkId, Collection<BenchmarkRunStatus> statuses);
 
+    Optional<BenchmarkRun> findFirstByBenchmarkEnvironmentIdAndStatusOrderByCreatedAtAsc(UUID environmentId, BenchmarkRunStatus status);
+
     @Query("SELECT br FROM BenchmarkRun br WHERE br.benchmark.environment.id = :environmentId")
     Page<BenchmarkRun> findByEnvironmentId(@Param("environmentId") UUID environmentId, Pageable pageable);
 }

--- a/src/test/java/dk/viplev/api/adapter/inbound/rest/AgentListMessagesIT.java
+++ b/src/test/java/dk/viplev/api/adapter/inbound/rest/AgentListMessagesIT.java
@@ -9,14 +9,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dk.viplev.api.domain.model.Benchmark;
-import dk.viplev.api.domain.model.BenchmarkRun;
 import dk.viplev.api.domain.model.BenchmarkRunStatus;
 import dk.viplev.api.domain.model.Environment;
-import dk.viplev.api.domain.model.User;
 import dk.viplev.api.port.outbound.db.BenchmarkRepository;
-import dk.viplev.api.port.outbound.db.BenchmarkRunRepository;
 import dk.viplev.api.port.outbound.db.EnvironmentRepository;
-import dk.viplev.api.port.outbound.db.UserRepository;
+import dk.viplev.api.util.TestObjectFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,10 +33,9 @@ class AgentListMessagesIT {
 
     @Autowired private MockMvc mockMvc;
     @Autowired private ObjectMapper objectMapper;
-    @Autowired private BenchmarkRunRepository benchmarkRunRepository;
     @Autowired private BenchmarkRepository benchmarkRepository;
-    @Autowired private UserRepository userRepository;
     @Autowired private EnvironmentRepository environmentRepository;
+    @Autowired private TestObjectFactory testObjectFactory;
 
     private String user1Token;
     private String user2Token;
@@ -61,9 +57,10 @@ class AgentListMessagesIT {
 
     @Test
     void shouldReturnPendingStopBeforePendingStartAndOnlyOneMessage() throws Exception {
-        UUID pendingStartRunId = createRunDirectly(UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.PENDING_START);
-        Thread.sleep(5);
-        UUID pendingStopRunId = createRunDirectly(UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.PENDING_STOP);
+        UUID pendingStartRunId = testObjectFactory.createBenchmarkRunDirectly(
+                UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.PENDING_START);
+        UUID pendingStopRunId = testObjectFactory.createBenchmarkRunDirectly(
+                UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.PENDING_STOP);
 
         mockMvc.perform(get(messageUrl(environmentId))
                         .header("Authorization", "Bearer " + environmentToken))
@@ -80,9 +77,12 @@ class AgentListMessagesIT {
     void shouldReturnOldestPendingStopMessage() throws Exception {
         String benchmark2Id = createBenchmark(user1Token, environmentId, "Agent Queue Benchmark 2");
 
-        UUID oldestStopRunId = createRunDirectly(UUID.fromString(benchmark2Id), "user1@viplev.dk", BenchmarkRunStatus.PENDING_STOP);
-        Thread.sleep(5);
-        createRunDirectly(UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.PENDING_STOP);
+        UUID oldestStopRunId = testObjectFactory.createBenchmarkRunDirectly(
+                UUID.fromString(benchmark2Id), "user1@viplev.dk", BenchmarkRunStatus.PENDING_STOP);
+        UUID newerStopRunId = testObjectFactory.createBenchmarkRunDirectly(
+                UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.PENDING_STOP);
+        testObjectFactory.setRunCreatedAt(oldestStopRunId, LocalDateTime.of(2026, 1, 1, 10, 0));
+        testObjectFactory.setRunCreatedAt(newerStopRunId, LocalDateTime.of(2026, 1, 1, 10, 1));
 
         mockMvc.perform(get(messageUrl(environmentId))
                         .header("Authorization", "Bearer " + environmentToken))
@@ -96,9 +96,12 @@ class AgentListMessagesIT {
     void shouldReturnOldestPendingStartWhenNoPendingStop() throws Exception {
         String benchmark2Id = createBenchmark(user1Token, environmentId, "Agent Queue Benchmark 3");
 
-        UUID oldestStartRunId = createRunDirectly(UUID.fromString(benchmark2Id), "user1@viplev.dk", BenchmarkRunStatus.PENDING_START);
-        Thread.sleep(5);
-        createRunDirectly(UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.PENDING_START);
+        UUID oldestStartRunId = testObjectFactory.createBenchmarkRunDirectly(
+                UUID.fromString(benchmark2Id), "user1@viplev.dk", BenchmarkRunStatus.PENDING_START);
+        UUID newerStartRunId = testObjectFactory.createBenchmarkRunDirectly(
+                UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.PENDING_START);
+        testObjectFactory.setRunCreatedAt(oldestStartRunId, LocalDateTime.of(2026, 1, 1, 11, 0));
+        testObjectFactory.setRunCreatedAt(newerStartRunId, LocalDateTime.of(2026, 1, 1, 11, 1));
 
         mockMvc.perform(get(messageUrl(environmentId))
                         .header("Authorization", "Bearer " + environmentToken))
@@ -110,7 +113,7 @@ class AgentListMessagesIT {
 
     @Test
     void shouldReturnEmptyListWhenNoPendingRuns() throws Exception {
-        createRunDirectly(UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.STARTED);
+        testObjectFactory.createBenchmarkRunDirectly(UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.STARTED);
 
         mockMvc.perform(get(messageUrl(environmentId))
                         .header("Authorization", "Bearer " + environmentToken))
@@ -134,12 +137,14 @@ class AgentListMessagesIT {
 
     @Test
     void shouldOnlyReturnMessagesForRequestedEnvironment() throws Exception {
-        UUID env1RunId = createRunDirectly(UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.PENDING_START);
+        UUID env1RunId = testObjectFactory.createBenchmarkRunDirectly(
+                UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.PENDING_START);
 
         JsonNode env2 = createEnvironmentAndGetResponse("Other Agent Env", user2Token);
         String env2Id = env2.get("id").asText();
         String benchmark2Id = createBenchmark(user2Token, env2Id, "Other Benchmark");
-        createRunDirectly(UUID.fromString(benchmark2Id), "user2@viplev.dk", BenchmarkRunStatus.PENDING_STOP);
+        testObjectFactory.createBenchmarkRunDirectly(
+                UUID.fromString(benchmark2Id), "user2@viplev.dk", BenchmarkRunStatus.PENDING_STOP);
 
         mockMvc.perform(get(messageUrl(environmentId))
                         .header("Authorization", "Bearer " + environmentToken))
@@ -154,7 +159,8 @@ class AgentListMessagesIT {
         JsonNode env2 = createEnvironmentAndGetResponse("Other Agent Env 2", user2Token);
         String env2Id = env2.get("id").asText();
         String benchmark2Id = createBenchmark(user2Token, env2Id, "Other Benchmark 2");
-        createRunDirectly(UUID.fromString(benchmark2Id), "user2@viplev.dk", BenchmarkRunStatus.PENDING_STOP);
+        testObjectFactory.createBenchmarkRunDirectly(
+                UUID.fromString(benchmark2Id), "user2@viplev.dk", BenchmarkRunStatus.PENDING_STOP);
 
         mockMvc.perform(get(messageUrl(env2Id))
                         .header("Authorization", "Bearer " + environmentToken))
@@ -203,14 +209,4 @@ class AgentListMessagesIT {
         return objectMapper.readTree(result.getResponse().getContentAsString()).get("id").asText();
     }
 
-    private UUID createRunDirectly(UUID benchmarkUuid, String userEmail, BenchmarkRunStatus status) {
-        Benchmark benchmark = benchmarkRepository.findById(benchmarkUuid).orElseThrow();
-        User user = userRepository.findByEmail(userEmail).orElseThrow();
-
-        BenchmarkRun run = new BenchmarkRun();
-        run.setBenchmark(benchmark);
-        run.setStartedByUser(user);
-        run.setStatus(status);
-        return benchmarkRunRepository.saveAndFlush(run).getId();
-    }
 }

--- a/src/test/java/dk/viplev/api/adapter/inbound/rest/AgentListMessagesIT.java
+++ b/src/test/java/dk/viplev/api/adapter/inbound/rest/AgentListMessagesIT.java
@@ -1,0 +1,216 @@
+package dk.viplev.api.adapter.inbound.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dk.viplev.api.domain.model.Benchmark;
+import dk.viplev.api.domain.model.BenchmarkRun;
+import dk.viplev.api.domain.model.BenchmarkRunStatus;
+import dk.viplev.api.domain.model.Environment;
+import dk.viplev.api.domain.model.User;
+import dk.viplev.api.port.outbound.db.BenchmarkRepository;
+import dk.viplev.api.port.outbound.db.BenchmarkRunRepository;
+import dk.viplev.api.port.outbound.db.EnvironmentRepository;
+import dk.viplev.api.port.outbound.db.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AgentListMessagesIT {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private BenchmarkRunRepository benchmarkRunRepository;
+    @Autowired private BenchmarkRepository benchmarkRepository;
+    @Autowired private UserRepository userRepository;
+    @Autowired private EnvironmentRepository environmentRepository;
+
+    private String user1Token;
+    private String user2Token;
+    private String environmentId;
+    private String environmentToken;
+    private String benchmarkId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        user1Token = loginAndGetToken("user1@viplev.dk", "password");
+        user2Token = loginAndGetToken("user2@viplev.dk", "password");
+
+        JsonNode env = createEnvironmentAndGetResponse("Agent Message Queue Env", user1Token);
+        environmentId = env.get("id").asText();
+        environmentToken = env.get("token").asText();
+
+        benchmarkId = createBenchmark(user1Token, environmentId, "Agent Queue Benchmark");
+    }
+
+    @Test
+    void shouldReturnPendingStopBeforePendingStartAndOnlyOneMessage() throws Exception {
+        UUID pendingStartRunId = createRunDirectly(UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.PENDING_START);
+        Thread.sleep(5);
+        UUID pendingStopRunId = createRunDirectly(UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.PENDING_STOP);
+
+        mockMvc.perform(get(messageUrl(environmentId))
+                        .header("Authorization", "Bearer " + environmentToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].benchmarkId").value(benchmarkId))
+                .andExpect(jsonPath("$[0].runId").value(pendingStopRunId.toString()))
+                .andExpect(jsonPath("$[0].messageType").value("PENDING_STOP"));
+
+        assertThat(pendingStartRunId).isNotEqualTo(pendingStopRunId);
+    }
+
+    @Test
+    void shouldReturnOldestPendingStopMessage() throws Exception {
+        String benchmark2Id = createBenchmark(user1Token, environmentId, "Agent Queue Benchmark 2");
+
+        UUID oldestStopRunId = createRunDirectly(UUID.fromString(benchmark2Id), "user1@viplev.dk", BenchmarkRunStatus.PENDING_STOP);
+        Thread.sleep(5);
+        createRunDirectly(UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.PENDING_STOP);
+
+        mockMvc.perform(get(messageUrl(environmentId))
+                        .header("Authorization", "Bearer " + environmentToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].runId").value(oldestStopRunId.toString()))
+                .andExpect(jsonPath("$[0].messageType").value("PENDING_STOP"));
+    }
+
+    @Test
+    void shouldReturnOldestPendingStartWhenNoPendingStop() throws Exception {
+        String benchmark2Id = createBenchmark(user1Token, environmentId, "Agent Queue Benchmark 3");
+
+        UUID oldestStartRunId = createRunDirectly(UUID.fromString(benchmark2Id), "user1@viplev.dk", BenchmarkRunStatus.PENDING_START);
+        Thread.sleep(5);
+        createRunDirectly(UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.PENDING_START);
+
+        mockMvc.perform(get(messageUrl(environmentId))
+                        .header("Authorization", "Bearer " + environmentToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].runId").value(oldestStartRunId.toString()))
+                .andExpect(jsonPath("$[0].messageType").value("PENDING_START"));
+    }
+
+    @Test
+    void shouldReturnEmptyListWhenNoPendingRuns() throws Exception {
+        createRunDirectly(UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.STARTED);
+
+        mockMvc.perform(get(messageUrl(environmentId))
+                        .header("Authorization", "Bearer " + environmentToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    @Test
+    void shouldUpdateAgentLastSeenAtOnPoll() throws Exception {
+        Environment before = environmentRepository.findById(UUID.fromString(environmentId)).orElseThrow();
+        assertThat(before.getAgentLastSeenAt()).isNull();
+
+        mockMvc.perform(get(messageUrl(environmentId))
+                        .header("Authorization", "Bearer " + environmentToken))
+                .andExpect(status().isOk());
+
+        Environment after = environmentRepository.findById(UUID.fromString(environmentId)).orElseThrow();
+        assertThat(after.getAgentLastSeenAt()).isNotNull();
+        assertThat(after.getAgentLastSeenAt()).isBeforeOrEqualTo(LocalDateTime.now());
+    }
+
+    @Test
+    void shouldOnlyReturnMessagesForRequestedEnvironment() throws Exception {
+        UUID env1RunId = createRunDirectly(UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.PENDING_START);
+
+        JsonNode env2 = createEnvironmentAndGetResponse("Other Agent Env", user2Token);
+        String env2Id = env2.get("id").asText();
+        String benchmark2Id = createBenchmark(user2Token, env2Id, "Other Benchmark");
+        createRunDirectly(UUID.fromString(benchmark2Id), "user2@viplev.dk", BenchmarkRunStatus.PENDING_STOP);
+
+        mockMvc.perform(get(messageUrl(environmentId))
+                        .header("Authorization", "Bearer " + environmentToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].runId").value(env1RunId.toString()))
+                .andExpect(jsonPath("$[0].messageType").value("PENDING_START"));
+    }
+
+    @Test
+    void shouldReturn404WhenAgentAccessesOtherEnvironment() throws Exception {
+        JsonNode env2 = createEnvironmentAndGetResponse("Other Agent Env 2", user2Token);
+        String env2Id = env2.get("id").asText();
+        String benchmark2Id = createBenchmark(user2Token, env2Id, "Other Benchmark 2");
+        createRunDirectly(UUID.fromString(benchmark2Id), "user2@viplev.dk", BenchmarkRunStatus.PENDING_STOP);
+
+        mockMvc.perform(get(messageUrl(env2Id))
+                        .header("Authorization", "Bearer " + environmentToken))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldReturn401WithoutToken() throws Exception {
+        mockMvc.perform(get(messageUrl(environmentId)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    private String messageUrl(String envId) {
+        return "/v1/environments/" + envId + "/message";
+    }
+
+    private String loginAndGetToken(String email, String password) throws Exception {
+        String loginJson = objectMapper.writeValueAsString(Map.of("email", email, "password", password));
+        MvcResult result = mockMvc.perform(post("/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(loginJson))
+                .andExpect(status().isOk())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString()).get("token").asText();
+    }
+
+    private JsonNode createEnvironmentAndGetResponse(String name, String token) throws Exception {
+        String json = objectMapper.writeValueAsString(Map.of("name", name, "type", "docker"));
+        MvcResult result = mockMvc.perform(post("/v1/environments")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString());
+    }
+
+    private String createBenchmark(String token, String envId, String name) throws Exception {
+        String json = objectMapper.writeValueAsString(Map.of("name", name));
+        MvcResult result = mockMvc.perform(post("/v1/environments/" + envId + "/benchmarks")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isCreated())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString()).get("id").asText();
+    }
+
+    private UUID createRunDirectly(UUID benchmarkUuid, String userEmail, BenchmarkRunStatus status) {
+        Benchmark benchmark = benchmarkRepository.findById(benchmarkUuid).orElseThrow();
+        User user = userRepository.findByEmail(userEmail).orElseThrow();
+
+        BenchmarkRun run = new BenchmarkRun();
+        run.setBenchmark(benchmark);
+        run.setStartedByUser(user);
+        run.setStatus(status);
+        return benchmarkRunRepository.saveAndFlush(run).getId();
+    }
+}

--- a/src/test/java/dk/viplev/api/domain/services/AgentServiceImplTest.java
+++ b/src/test/java/dk/viplev/api/domain/services/AgentServiceImplTest.java
@@ -14,6 +14,7 @@ import dk.viplev.api.adapter.inbound.rest.dto.MetricResourceDTO;
 import dk.viplev.api.adapter.inbound.rest.dto.MetricResourceNodeDTO;
 import dk.viplev.api.adapter.inbound.rest.dto.MetricResourceServiceDTO;
 import dk.viplev.api.adapter.inbound.rest.mapper.BenchmarkRunMapper;
+import dk.viplev.api.adapter.inbound.rest.mapper.MessageMapper;
 import dk.viplev.api.domain.exception.BadRequestException;
 import dk.viplev.api.domain.exception.NotFoundException;
 import dk.viplev.api.domain.model.BenchmarkRun;
@@ -23,6 +24,7 @@ import dk.viplev.api.domain.model.Service;
 import dk.viplev.api.port.inbound.AuthService;
 import dk.viplev.api.port.outbound.db.BenchmarkRepository;
 import dk.viplev.api.port.outbound.db.BenchmarkRunRepository;
+import dk.viplev.api.port.outbound.db.EnvironmentRepository;
 import dk.viplev.api.port.outbound.db.HostRepository;
 import dk.viplev.api.port.outbound.db.MetricK6HttpRepository;
 import dk.viplev.api.port.outbound.db.MetricK6VusRepository;
@@ -52,8 +54,10 @@ class AgentServiceImplTest {
     @Mock private MetricResourceServiceRepository metricResourceServiceRepository;
     @Mock private MetricK6HttpRepository metricK6HttpRepository;
     @Mock private MetricK6VusRepository metricK6VusRepository;
+    @Mock private EnvironmentRepository environmentRepository;
     @Mock private AuthService authService;
     @Mock private BenchmarkRunMapper benchmarkRunMapper;
+    @Mock private MessageMapper messageMapper;
 
     private AgentServiceImpl agentService;
 
@@ -69,7 +73,8 @@ class AgentServiceImplTest {
                 benchmarkRunRepository, benchmarkRepository, hostRepository, serviceRepository,
                 metricResourceHostRepository, metricResourceServiceRepository,
                 metricK6HttpRepository, metricK6VusRepository,
-                authService, benchmarkRunMapper);
+                environmentRepository,
+                authService, benchmarkRunMapper, messageMapper);
 
         activeRun = new BenchmarkRun();
         activeRun.setId(runId);

--- a/src/test/java/dk/viplev/api/util/TestObjectFactory.java
+++ b/src/test/java/dk/viplev/api/util/TestObjectFactory.java
@@ -8,8 +8,11 @@ import dk.viplev.api.port.outbound.db.BenchmarkRepository;
 import dk.viplev.api.port.outbound.db.BenchmarkRunRepository;
 import dk.viplev.api.port.outbound.db.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Component
@@ -24,14 +27,32 @@ public class TestObjectFactory {
     @Autowired
     private UserRepository userRepository;
 
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
     public UUID createBenchmarkRunDirectly(UUID benchmarkUuid, String userEmail) {
+        return createBenchmarkRunDirectly(benchmarkUuid, userEmail, BenchmarkRunStatus.PENDING_START);
+    }
+
+    public UUID createBenchmarkRunDirectly(UUID benchmarkUuid, String userEmail, BenchmarkRunStatus status) {
         Benchmark benchmark = benchmarkRepository.findById(benchmarkUuid).orElseThrow();
         User user = userRepository.findByEmail(userEmail).orElseThrow();
 
         BenchmarkRun run = new BenchmarkRun();
         run.setBenchmark(benchmark);
         run.setStartedByUser(user);
-        run.setStatus(BenchmarkRunStatus.PENDING_START);
+        run.setStatus(status);
         return benchmarkRunRepository.saveAndFlush(run).getId();
+    }
+
+    public void setRunCreatedAt(UUID runId, LocalDateTime createdAt) {
+        int updatedRows = jdbcTemplate.update(
+                "UPDATE benchmark_runs SET created_at = ? WHERE id = ?",
+                Timestamp.valueOf(createdAt),
+                runId
+        );
+        if (updatedRows != 1) {
+            throw new IllegalStateException("Expected 1 row to be updated for run " + runId + ", but was " + updatedRows);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- implement GET /v1/environments/{environmentId}/message for agent polling
- return at most one message with PENDING_STOP priority before PENDING_START
- update environment.agentLastSeenAt on each poll and add integration coverage

Closes #9