### PR TITLE
fix(agent): include benchmark data in start messages (#50)

### DIFF
--- a/src/main/java/dk/viplev/api/adapter/inbound/rest/mapper/MessageMapper.java
+++ b/src/main/java/dk/viplev/api/adapter/inbound/rest/mapper/MessageMapper.java
@@ -1,6 +1,8 @@
 package dk.viplev.api.adapter.inbound.rest.mapper;
 
+import dk.viplev.api.adapter.inbound.rest.dto.BenchmarkDTO;
 import dk.viplev.api.adapter.inbound.rest.dto.MessageDTO;
+import dk.viplev.api.domain.model.Benchmark;
 import dk.viplev.api.domain.model.BenchmarkRun;
 import dk.viplev.api.domain.model.BenchmarkRunStatus;
 import org.mapstruct.Mapper;
@@ -13,6 +15,7 @@ public interface MessageMapper {
     @Mapping(source = "benchmark.id", target = "benchmarkId")
     @Mapping(source = "id", target = "runId")
     @Mapping(source = "status", target = "messageType", qualifiedByName = "toMessageType")
+    @Mapping(target = "benchmarkData", expression = "java(toBenchmarkData(benchmarkRun))")
     MessageDTO toDto(BenchmarkRun benchmarkRun);
 
     @Named("toMessageType")
@@ -22,5 +25,26 @@ public interface MessageMapper {
             case PENDING_STOP -> MessageDTO.MessageTypeEnum.PENDING_STOP;
             default -> throw new IllegalArgumentException("Unsupported message status: " + status);
         };
+    }
+
+    default BenchmarkDTO toBenchmarkData(BenchmarkRun benchmarkRun) {
+        if (benchmarkRun.getStatus() != BenchmarkRunStatus.PENDING_START) {
+            return null;
+        }
+
+        Benchmark benchmark = benchmarkRun.getBenchmark();
+        if (benchmark == null) {
+            return null;
+        }
+
+        BenchmarkDTO dto = new BenchmarkDTO();
+        dto.setId(benchmark.getId());
+        dto.setName(benchmark.getName());
+        dto.setDescription(benchmark.getDescription());
+        dto.setK6Instructions(benchmark.getK6Instructions());
+        dto.setCreatedAt(benchmark.getCreatedAt());
+        dto.setUpdatedAt(benchmark.getUpdatedAt());
+
+        return dto;
     }
 }

--- a/src/main/java/dk/viplev/api/adapter/inbound/rest/mapper/MessageMapper.java
+++ b/src/main/java/dk/viplev/api/adapter/inbound/rest/mapper/MessageMapper.java
@@ -1,8 +1,6 @@
 package dk.viplev.api.adapter.inbound.rest.mapper;
 
-import dk.viplev.api.adapter.inbound.rest.dto.BenchmarkDTO;
 import dk.viplev.api.adapter.inbound.rest.dto.MessageDTO;
-import dk.viplev.api.domain.model.Benchmark;
 import dk.viplev.api.domain.model.BenchmarkRun;
 import dk.viplev.api.domain.model.BenchmarkRunStatus;
 import org.mapstruct.Mapper;
@@ -15,7 +13,7 @@ public interface MessageMapper {
     @Mapping(source = "benchmark.id", target = "benchmarkId")
     @Mapping(source = "id", target = "runId")
     @Mapping(source = "status", target = "messageType", qualifiedByName = "toMessageType")
-    @Mapping(target = "benchmarkData", expression = "java(toBenchmarkData(benchmarkRun))")
+    @Mapping(target = "benchmarkData", ignore = true)
     MessageDTO toDto(BenchmarkRun benchmarkRun);
 
     @Named("toMessageType")
@@ -25,26 +23,5 @@ public interface MessageMapper {
             case PENDING_STOP -> MessageDTO.MessageTypeEnum.PENDING_STOP;
             default -> throw new IllegalArgumentException("Unsupported message status: " + status);
         };
-    }
-
-    default BenchmarkDTO toBenchmarkData(BenchmarkRun benchmarkRun) {
-        if (benchmarkRun.getStatus() != BenchmarkRunStatus.PENDING_START) {
-            return null;
-        }
-
-        Benchmark benchmark = benchmarkRun.getBenchmark();
-        if (benchmark == null) {
-            return null;
-        }
-
-        BenchmarkDTO dto = new BenchmarkDTO();
-        dto.setId(benchmark.getId());
-        dto.setName(benchmark.getName());
-        dto.setDescription(benchmark.getDescription());
-        dto.setK6Instructions(benchmark.getK6Instructions());
-        dto.setCreatedAt(benchmark.getCreatedAt());
-        dto.setUpdatedAt(benchmark.getUpdatedAt());
-
-        return dto;
     }
 }

--- a/src/main/java/dk/viplev/api/domain/services/AgentServiceImpl.java
+++ b/src/main/java/dk/viplev/api/domain/services/AgentServiceImpl.java
@@ -10,6 +10,7 @@ import dk.viplev.api.adapter.inbound.rest.dto.MetricDataPointDTO;
 import dk.viplev.api.adapter.inbound.rest.dto.MetricResourceDTO;
 import dk.viplev.api.adapter.inbound.rest.dto.MetricResourceNodeDTO;
 import dk.viplev.api.adapter.inbound.rest.dto.MetricResourceServiceDTO;
+import dk.viplev.api.adapter.inbound.rest.mapper.BenchmarkMapper;
 import dk.viplev.api.adapter.inbound.rest.mapper.BenchmarkRunMapper;
 import dk.viplev.api.adapter.inbound.rest.mapper.MessageMapper;
 import dk.viplev.api.domain.exception.BadRequestException;
@@ -66,6 +67,7 @@ public class AgentServiceImpl implements AgentService {
     private final MetricK6VusRepository metricK6VusRepository;
     private final EnvironmentRepository environmentRepository;
     private final AuthService authService;
+    private final BenchmarkMapper benchmarkMapper;
     private final BenchmarkRunMapper benchmarkRunMapper;
     private final MessageMapper messageMapper;
 
@@ -81,13 +83,21 @@ public class AgentServiceImpl implements AgentService {
 
         return benchmarkRunRepository
                 .findFirstByBenchmarkEnvironmentIdAndStatusOrderByCreatedAtAsc(environmentId, BenchmarkRunStatus.PENDING_STOP)
-                .map(messageMapper::toDto)
+                .map(this::toMessageDto)
                 .map(List::of)
                 .orElseGet(() -> benchmarkRunRepository
                         .findFirstByBenchmarkEnvironmentIdAndStatusOrderByCreatedAtAsc(environmentId, BenchmarkRunStatus.PENDING_START)
-                        .map(messageMapper::toDto)
+                        .map(this::toMessageDto)
                         .map(List::of)
                         .orElseGet(List::of));
+    }
+
+    private MessageDTO toMessageDto(BenchmarkRun run) {
+        MessageDTO dto = messageMapper.toDto(run);
+        if (run.getStatus() == BenchmarkRunStatus.PENDING_START && run.getBenchmark() != null) {
+            dto.setBenchmarkData(benchmarkMapper.toDto(run.getBenchmark()));
+        }
+        return dto;
     }
 
     @Override

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -1729,6 +1729,9 @@ components:
           type: string
           enum: [PENDING_START, PENDING_STOP]
           description: Type of message for the agent
+        benchmarkData:
+          $ref: '#/components/schemas/BenchmarkDTO'
+          description: Benchmark payload included for PENDING_START messages
 
     ErrorDTO:
       type: object

--- a/src/test/java/dk/viplev/api/adapter/inbound/rest/AgentListMessagesIT.java
+++ b/src/test/java/dk/viplev/api/adapter/inbound/rest/AgentListMessagesIT.java
@@ -68,7 +68,8 @@ class AgentListMessagesIT {
                 .andExpect(jsonPath("$.length()").value(1))
                 .andExpect(jsonPath("$[0].benchmarkId").value(benchmarkId))
                 .andExpect(jsonPath("$[0].runId").value(pendingStopRunId.toString()))
-                .andExpect(jsonPath("$[0].messageType").value("PENDING_STOP"));
+                .andExpect(jsonPath("$[0].messageType").value("PENDING_STOP"))
+                .andExpect(jsonPath("$[0].benchmarkData").doesNotExist());
 
         assertThat(pendingStartRunId).isNotEqualTo(pendingStopRunId);
     }
@@ -108,7 +109,9 @@ class AgentListMessagesIT {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(1))
                 .andExpect(jsonPath("$[0].runId").value(oldestStartRunId.toString()))
-                .andExpect(jsonPath("$[0].messageType").value("PENDING_START"));
+                .andExpect(jsonPath("$[0].messageType").value("PENDING_START"))
+                .andExpect(jsonPath("$[0].benchmarkData.id").value(benchmark2Id))
+                .andExpect(jsonPath("$[0].benchmarkData.name").value("Agent Queue Benchmark 3"));
     }
 
     @Test

--- a/src/test/java/dk/viplev/api/domain/services/AgentServiceImplTest.java
+++ b/src/test/java/dk/viplev/api/domain/services/AgentServiceImplTest.java
@@ -13,6 +13,7 @@ import dk.viplev.api.adapter.inbound.rest.dto.MetricDataPointDTO;
 import dk.viplev.api.adapter.inbound.rest.dto.MetricResourceDTO;
 import dk.viplev.api.adapter.inbound.rest.dto.MetricResourceNodeDTO;
 import dk.viplev.api.adapter.inbound.rest.dto.MetricResourceServiceDTO;
+import dk.viplev.api.adapter.inbound.rest.mapper.BenchmarkMapper;
 import dk.viplev.api.adapter.inbound.rest.mapper.BenchmarkRunMapper;
 import dk.viplev.api.adapter.inbound.rest.mapper.MessageMapper;
 import dk.viplev.api.domain.exception.BadRequestException;
@@ -56,6 +57,7 @@ class AgentServiceImplTest {
     @Mock private MetricK6VusRepository metricK6VusRepository;
     @Mock private EnvironmentRepository environmentRepository;
     @Mock private AuthService authService;
+    @Mock private BenchmarkMapper benchmarkMapper;
     @Mock private BenchmarkRunMapper benchmarkRunMapper;
     @Mock private MessageMapper messageMapper;
 
@@ -74,7 +76,7 @@ class AgentServiceImplTest {
                 metricResourceHostRepository, metricResourceServiceRepository,
                 metricK6HttpRepository, metricK6VusRepository,
                 environmentRepository,
-                authService, benchmarkRunMapper, messageMapper);
+                authService, benchmarkMapper, benchmarkRunMapper, messageMapper);
 
         activeRun = new BenchmarkRun();
         activeRun.setId(runId);


### PR DESCRIPTION
## Summary
- Add optional `benchmarkData` to `MessageDTO` in OpenAPI so agent queue messages can include benchmark payload.
- Populate `benchmarkData` only for `PENDING_START` messages in `MessageMapper`; keep it absent for `PENDING_STOP`.
- Extend `AgentListMessagesIT` to verify start messages include benchmark payload and stop messages omit it.

## Validation
- `./gradlew test --tests "dk.viplev.api.adapter.inbound.rest.AgentListMessagesIT"`
- `./gradlew test --tests "dk.viplev.api.adapter.inbound.rest.Agent*IT"`
- `./gradlew test`

Fixes #50