### PR TITLE
fix(agent): add detailed logging for agent endpoint flow (#53)

### DIFF
--- a/src/main/java/dk/viplev/api/adapter/inbound/rest/AgentApiDelegateImpl.java
+++ b/src/main/java/dk/viplev/api/adapter/inbound/rest/AgentApiDelegateImpl.java
@@ -27,30 +27,46 @@ public class AgentApiDelegateImpl implements AgentApiDelegate {
 
     @Override
     public ResponseEntity<List<MessageDTO>> listMessages(UUID environmentId) {
+        log.info("Agent request received: listMessages, environmentId={}", environmentId);
         return ResponseEntity.ok(agentService.listMessages(environmentId));
     }
 
     @Override
     public ResponseEntity<Void> registerServices(UUID environmentId, ServiceRegistrationDTO serviceRegistrationDTO) {
+        log.info("Agent request received: registerServices, environmentId={}", environmentId);
+
         serviceService.registerServices(environmentId, serviceRegistrationDTO);
+
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @Override
     public ResponseEntity<BenchmarkRunDTO> updateBenchmarkRunStatus(UUID environmentId, UUID benchmarkId, UUID runId, BenchmarkRunStatusUpdateDTO benchmarkRunStatusUpdateDTO) {
+        log.info("Agent request received: updateBenchmarkRunStatus, environmentId={}, benchmarkId={}, runId={}",
+                environmentId, benchmarkId, runId);
+
         BenchmarkRunDTO dto = agentService.updateBenchmarkRunStatus(environmentId, benchmarkId, runId, benchmarkRunStatusUpdateDTO);
+
         return ResponseEntity.ok(dto);
     }
 
     @Override
     public ResponseEntity<Void> storeResourceMetrics(UUID environmentId, UUID benchmarkId, UUID runId, MetricResourceDTO metricResourceDTO) {
+        log.info("Agent request received: storeResourceMetrics, environmentId={}, benchmarkId={}, runId={}",
+                environmentId, benchmarkId, runId);
+
         agentService.storeResourceMetrics(environmentId, benchmarkId, runId, metricResourceDTO);
+
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @Override
     public ResponseEntity<Void> storePerformanceMetrics(UUID environmentId, UUID benchmarkId, UUID runId, MetricPerformanceDTO metricPerformanceDTO) {
+        log.info("Agent request received: storePerformanceMetrics, environmentId={}, benchmarkId={}, runId={}",
+                environmentId, benchmarkId, runId);
+
         agentService.storePerformanceMetrics(environmentId, benchmarkId, runId, metricPerformanceDTO);
+
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 }

--- a/src/main/java/dk/viplev/api/domain/services/AgentServiceImpl.java
+++ b/src/main/java/dk/viplev/api/domain/services/AgentServiceImpl.java
@@ -36,6 +36,7 @@ import dk.viplev.api.port.outbound.db.MetricResourceHostRepository;
 import dk.viplev.api.port.outbound.db.MetricResourceServiceRepository;
 import dk.viplev.api.port.outbound.db.ServiceRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
@@ -49,6 +50,7 @@ import java.util.stream.Collectors;
 
 @org.springframework.stereotype.Service
 @RequiredArgsConstructor
+@Slf4j
 public class AgentServiceImpl implements AgentService {
 
     private static final Map<BenchmarkRunStatus, Set<BenchmarkRunStatus>> VALID_TRANSITIONS = Map.of(
@@ -74,22 +76,40 @@ public class AgentServiceImpl implements AgentService {
     @Override
     @Transactional
     public List<MessageDTO> listMessages(UUID environmentId) {
+        log.info("Listing agent messages: environmentId={}", environmentId);
         validateEnvironmentAccess(environmentId);
 
         Environment environment = environmentRepository.findById(environmentId)
                 .orElseThrow(() -> new NotFoundException("Environment not found"));
         environment.setAgentLastSeenAt(LocalDateTime.now());
         environmentRepository.save(environment);
+        log.info("Agent heartbeat updated: environmentId={}, agentLastSeenAt={}",
+                environmentId, environment.getAgentLastSeenAt());
 
-        return benchmarkRunRepository
+        BenchmarkRun pendingStopRun = benchmarkRunRepository
                 .findFirstByBenchmarkEnvironmentIdAndStatusOrderByCreatedAtAsc(environmentId, BenchmarkRunStatus.PENDING_STOP)
-                .map(this::toMessageDto)
-                .map(List::of)
-                .orElseGet(() -> benchmarkRunRepository
-                        .findFirstByBenchmarkEnvironmentIdAndStatusOrderByCreatedAtAsc(environmentId, BenchmarkRunStatus.PENDING_START)
-                        .map(this::toMessageDto)
-                        .map(List::of)
-                        .orElseGet(List::of));
+                .orElse(null);
+
+        if (pendingStopRun != null) {
+            MessageDTO message = toMessageDto(pendingStopRun);
+            log.info("Returning agent message: environmentId={}, messageType={}, benchmarkId={}, runId={}",
+                    environmentId, message.getMessageType(), message.getBenchmarkId(), message.getRunId());
+            return List.of(message);
+        }
+
+        BenchmarkRun pendingStartRun = benchmarkRunRepository
+                .findFirstByBenchmarkEnvironmentIdAndStatusOrderByCreatedAtAsc(environmentId, BenchmarkRunStatus.PENDING_START)
+                .orElse(null);
+
+        if (pendingStartRun != null) {
+            MessageDTO message = toMessageDto(pendingStartRun);
+            log.info("Returning agent message: environmentId={}, messageType={}, benchmarkId={}, runId={}",
+                    environmentId, message.getMessageType(), message.getBenchmarkId(), message.getRunId());
+            return List.of(message);
+        }
+
+        log.info("No pending agent message found: environmentId={}", environmentId);
+        return List.of();
     }
 
     private MessageDTO toMessageDto(BenchmarkRun run) {
@@ -111,9 +131,13 @@ public class AgentServiceImpl implements AgentService {
         BenchmarkRun run = benchmarkRunRepository.findByIdAndBenchmarkId(runId, benchmarkId)
                 .orElseThrow(() -> new NotFoundException("Benchmark run not found"));
 
+        BenchmarkRunStatus currentStatus = run.getStatus();
         BenchmarkRunStatus newStatus = BenchmarkRunStatus.valueOf(dto.getStatus().name());
 
-        validateTransition(run.getStatus(), newStatus);
+        log.info("Run status update requested: environmentId={}, benchmarkId={}, runId={}, currentStatus={}, requestedStatus={}, statusReason={}",
+                environmentId, benchmarkId, runId, currentStatus, newStatus, dto.getStatusReason());
+
+        validateTransition(currentStatus, newStatus);
         validateStatusReason(newStatus, dto.getStatusReason());
 
         run.setStatus(newStatus);
@@ -127,6 +151,8 @@ public class AgentServiceImpl implements AgentService {
         }
 
         benchmarkRunRepository.save(run);
+        log.info("Run status update persisted: environmentId={}, benchmarkId={}, runId={}, previousStatus={}, persistedStatus={}, startedAt={}, finishedAt={}, statusReason={}",
+                environmentId, benchmarkId, runId, currentStatus, run.getStatus(), run.getStartedAt(), run.getFinishedAt(), run.getStatusReason());
 
         return benchmarkRunMapper.toDto(run);
     }
@@ -134,6 +160,10 @@ public class AgentServiceImpl implements AgentService {
     @Override
     @Transactional
     public void storeResourceMetrics(UUID environmentId, UUID benchmarkId, UUID runId, MetricResourceDTO dto) {
+        int hostCount = dto != null && dto.getHosts() != null ? dto.getHosts().size() : 0;
+        log.info("Storing resource metrics: environmentId={}, benchmarkId={}, runId={}, hostCount={}",
+                environmentId, benchmarkId, runId, hostCount);
+
         validateEnvironmentAccess(environmentId);
 
         benchmarkRepository.findByIdAndEnvironmentId(benchmarkId, environmentId)
@@ -150,6 +180,9 @@ public class AgentServiceImpl implements AgentService {
         if (dto.getHosts() == null) {
             throw new BadRequestException("Invalid resource metrics", "hosts must not be null");
         }
+
+        int totalHostMetricDataPoints = 0;
+        int totalServiceMetricDataPoints = 0;
 
         // Process metrics for each node in the payload
         for (MetricResourceNodeDTO node : dto.getHosts()) {
@@ -181,8 +214,10 @@ public class AgentServiceImpl implements AgentService {
                         dp.getBlockOutBytes()));
             }
             metricResourceHostRepository.saveAll(hostMetrics);
+            totalHostMetricDataPoints += hostMetrics.size();
 
             // Service metrics — batch-fetch all services for the host in one query
+            int currentHostServiceMetricDataPoints = 0;
             if (node.getServices() != null && !node.getServices().isEmpty()) {
                 for (MetricResourceServiceDTO serviceDto : node.getServices()) {
                     if (serviceDto == null) {
@@ -229,13 +264,27 @@ public class AgentServiceImpl implements AgentService {
                     }
                 }
                 metricResourceServiceRepository.saveAll(serviceMetrics);
+                currentHostServiceMetricDataPoints = serviceMetrics.size();
+                totalServiceMetricDataPoints += currentHostServiceMetricDataPoints;
             }
+
+            int serviceCount = node.getServices() != null ? node.getServices().size() : 0;
+            log.info("Stored resource metrics for host: environmentId={}, benchmarkId={}, runId={}, machineId={}, hostDataPoints={}, serviceCount={}, serviceDataPoints={}",
+                    environmentId, benchmarkId, runId, machineId, hostMetrics.size(), serviceCount, currentHostServiceMetricDataPoints);
         }
+
+        log.info("Resource metrics storage completed: environmentId={}, benchmarkId={}, runId={}, hostCount={}, totalHostDataPoints={}, totalServiceDataPoints={}",
+                environmentId, benchmarkId, runId, dto.getHosts().size(), totalHostMetricDataPoints, totalServiceMetricDataPoints);
     }
 
     @Override
     @Transactional
     public void storePerformanceMetrics(UUID environmentId, UUID benchmarkId, UUID runId, MetricPerformanceDTO dto) {
+        int httpMetricCount = dto != null && dto.getHttpMetrics() != null ? dto.getHttpMetrics().size() : 0;
+        int vusMetricCount = dto != null && dto.getVusMetrics() != null ? dto.getVusMetrics().size() : 0;
+        log.info("Storing performance metrics: environmentId={}, benchmarkId={}, runId={}, httpMetricCount={}, vusMetricCount={}",
+                environmentId, benchmarkId, runId, httpMetricCount, vusMetricCount);
+
         validateEnvironmentAccess(environmentId);
 
         benchmarkRepository.findByIdAndEnvironmentId(benchmarkId, environmentId)
@@ -270,11 +319,16 @@ public class AgentServiceImpl implements AgentService {
             }
             metricK6VusRepository.saveAll(vusMetrics);
         }
+
+        log.info("Performance metrics storage completed: environmentId={}, benchmarkId={}, runId={}, persistedHttpMetrics={}, persistedVusMetrics={}",
+                environmentId, benchmarkId, runId, httpMetricCount, vusMetricCount);
     }
 
     private void validateEnvironmentAccess(UUID environmentId) {
         UUID tokenEnvironmentId = authService.getAuthenticatedEnvironmentId();
         if (!environmentId.equals(tokenEnvironmentId)) {
+            log.info("Environment access denied for agent request: environmentId={}, tokenEnvironmentId={}",
+                    environmentId, tokenEnvironmentId);
             throw new NotFoundException("Environment not found");
         }
     }

--- a/src/main/java/dk/viplev/api/domain/services/AgentServiceImpl.java
+++ b/src/main/java/dk/viplev/api/domain/services/AgentServiceImpl.java
@@ -160,6 +160,10 @@ public class AgentServiceImpl implements AgentService {
     @Override
     @Transactional
     public void storeResourceMetrics(UUID environmentId, UUID benchmarkId, UUID runId, MetricResourceDTO dto) {
+        if (dto == null) {
+            throw new BadRequestException("Invalid resource metrics", "request body must not be null");
+        }
+
         int hostCount = dto != null && dto.getHosts() != null ? dto.getHosts().size() : 0;
         log.info("Storing resource metrics: environmentId={}, benchmarkId={}, runId={}, hostCount={}",
                 environmentId, benchmarkId, runId, hostCount);
@@ -269,7 +273,7 @@ public class AgentServiceImpl implements AgentService {
             }
 
             int serviceCount = node.getServices() != null ? node.getServices().size() : 0;
-            log.info("Stored resource metrics for host: environmentId={}, benchmarkId={}, runId={}, machineId={}, hostDataPoints={}, serviceCount={}, serviceDataPoints={}",
+            log.debug("Stored resource metrics for host: environmentId={}, benchmarkId={}, runId={}, machineId={}, hostDataPoints={}, serviceCount={}, serviceDataPoints={}",
                     environmentId, benchmarkId, runId, machineId, hostMetrics.size(), serviceCount, currentHostServiceMetricDataPoints);
         }
 
@@ -280,6 +284,10 @@ public class AgentServiceImpl implements AgentService {
     @Override
     @Transactional
     public void storePerformanceMetrics(UUID environmentId, UUID benchmarkId, UUID runId, MetricPerformanceDTO dto) {
+        if (dto == null) {
+            throw new BadRequestException("Invalid performance metrics", "request body must not be null");
+        }
+
         int httpMetricCount = dto != null && dto.getHttpMetrics() != null ? dto.getHttpMetrics().size() : 0;
         int vusMetricCount = dto != null && dto.getVusMetrics() != null ? dto.getVusMetrics().size() : 0;
         log.info("Storing performance metrics: environmentId={}, benchmarkId={}, runId={}, httpMetricCount={}, vusMetricCount={}",
@@ -327,7 +335,8 @@ public class AgentServiceImpl implements AgentService {
     private void validateEnvironmentAccess(UUID environmentId) {
         UUID tokenEnvironmentId = authService.getAuthenticatedEnvironmentId();
         if (!environmentId.equals(tokenEnvironmentId)) {
-            log.info("Environment access denied for agent request: environmentId={}, tokenEnvironmentId={}",
+            log.info("Environment access denied for agent request: environmentId={}", environmentId);
+            log.debug("Environment access denied details: environmentId={}, tokenEnvironmentId={}",
                     environmentId, tokenEnvironmentId);
             throw new NotFoundException("Environment not found");
         }

--- a/src/main/java/dk/viplev/api/domain/services/ServiceServiceImpl.java
+++ b/src/main/java/dk/viplev/api/domain/services/ServiceServiceImpl.java
@@ -52,6 +52,11 @@ public class ServiceServiceImpl implements ServiceService {
     @Override
     @Transactional
     public void registerServices(UUID environmentId, ServiceRegistrationDTO registration) {
+        int hostCount = registration != null && registration.getHosts() != null ? registration.getHosts().size() : 0;
+        int serviceCount = countServices(registration);
+        log.info("Registering services for environment: environmentId={}, hostCount={}, serviceCount={}",
+                environmentId, hostCount, serviceCount);
+
         UUID agentEnvironmentId = authService.getAuthenticatedEnvironmentId();
         if (agentEnvironmentId == null || !agentEnvironmentId.equals(environmentId)) {
             throw new BadRequestException("Agent token does not match the environment");
@@ -85,6 +90,10 @@ public class ServiceServiceImpl implements ServiceService {
         var environment = environmentRepository.findById(environmentId)
                 .orElseThrow(() -> new NotFoundException("Environment not found"));
 
+        int servicesCreated = 0;
+        int servicesUpdated = 0;
+        int servicesDeleted = 0;
+
         for (ServiceRegistrationHostDTO hostEntry : registration.getHosts()) {
 
             HostDTO hostDto = hostEntry.getHost();
@@ -108,11 +117,15 @@ public class ServiceServiceImpl implements ServiceService {
             host.setRamType(hostDto.getRamType());
             host = hostRepository.save(host);
 
+            int hostIncomingServiceCount = hostEntry.getServices() != null ? hostEntry.getServices().size() : 0;
+
             Map<String, dk.viplev.api.domain.model.Service> existingByName =
                     serviceRepository.findByHostId(host.getId()).stream()
                             .collect(Collectors.toMap(dk.viplev.api.domain.model.Service::getServiceName, s -> s));
 
             Set<String> incomingServiceNames = new HashSet<>();
+            int hostServicesCreated = 0;
+            int hostServicesUpdated = 0;
             for (ServiceDTO dto : hostEntry.getServices()) {
                 incomingServiceNames.add(dto.getServiceName());
 
@@ -125,6 +138,8 @@ public class ServiceServiceImpl implements ServiceService {
                     existing.setMemoryLimitBytes(dto.getMemoryLimitBytes());
                     existing.setMemoryReservationBytes(dto.getMemoryReservationBytes());
                     serviceRepository.save(existing);
+                    hostServicesUpdated++;
+                    servicesUpdated++;
                 } else {
                     var svc = new dk.viplev.api.domain.model.Service();
                     svc.setHost(host);
@@ -136,13 +151,42 @@ public class ServiceServiceImpl implements ServiceService {
                     svc.setMemoryLimitBytes(dto.getMemoryLimitBytes());
                     svc.setMemoryReservationBytes(dto.getMemoryReservationBytes());
                     serviceRepository.save(svc);
+                    hostServicesCreated++;
+                    servicesCreated++;
                 }
             }
 
-            existingByName.values().stream()
+            List<dk.viplev.api.domain.model.Service> servicesToDelete = existingByName.values().stream()
                     .filter(s -> !incomingServiceNames.contains(s.getServiceName()))
-                    .forEach(serviceRepository::delete);
+                    .toList();
+            servicesToDelete.forEach(serviceRepository::delete);
+            servicesDeleted += servicesToDelete.size();
+
+            log.info("Registered services for host: environmentId={}, machineId={}, incomingServiceCount={}, created={}, updated={}, deleted={}",
+                    environmentId,
+                    hostDto.getMachineId(),
+                    hostIncomingServiceCount,
+                    hostServicesCreated,
+                    hostServicesUpdated,
+                    servicesToDelete.size());
         }
+
+        log.info("Service registration completed: environmentId={}, hostCount={}, serviceCount={}, servicesCreated={}, servicesUpdated={}, servicesDeleted={}",
+                environmentId, registration.getHosts().size(), serviceCount, servicesCreated, servicesUpdated, servicesDeleted);
+    }
+
+    private int countServices(ServiceRegistrationDTO registration) {
+        if (registration == null || registration.getHosts() == null) {
+            return 0;
+        }
+
+        int count = 0;
+        for (ServiceRegistrationHostDTO hostEntry : registration.getHosts()) {
+            if (hostEntry != null && hostEntry.getServices() != null) {
+                count += hostEntry.getServices().size();
+            }
+        }
+        return count;
     }
 
     private void validateServiceNames(List<ServiceDTO> services) {

--- a/src/main/java/dk/viplev/api/domain/services/ServiceServiceImpl.java
+++ b/src/main/java/dk/viplev/api/domain/services/ServiceServiceImpl.java
@@ -52,7 +52,11 @@ public class ServiceServiceImpl implements ServiceService {
     @Override
     @Transactional
     public void registerServices(UUID environmentId, ServiceRegistrationDTO registration) {
-        int hostCount = registration != null && registration.getHosts() != null ? registration.getHosts().size() : 0;
+        if (registration == null) {
+            throw new BadRequestException("Invalid registration", "body must not be null");
+        }
+
+        int hostCount = registration.getHosts() != null ? registration.getHosts().size() : 0;
         int serviceCount = countServices(registration);
         log.info("Registering services for environment: environmentId={}, hostCount={}, serviceCount={}",
                 environmentId, hostCount, serviceCount);


### PR DESCRIPTION
## Summary
- add lightweight request-entry logs in `AgentApiDelegateImpl` for all five agent endpoints
- add detailed service-layer logs in `AgentServiceImpl` and `ServiceServiceImpl` with environment/benchmark/run context, status transitions, and metric/service counts
- include `statusReason` in run status update logs and explicit service totals for `/services`

## Verification
- `./gradlew test`