### PR TITLE
feat(benchmark-services): scope benchmark metrics to selected services

### DIFF
--- a/src/main/java/dk/viplev/api/adapter/inbound/rest/BenchmarkApiDelegateImpl.java
+++ b/src/main/java/dk/viplev/api/adapter/inbound/rest/BenchmarkApiDelegateImpl.java
@@ -1,6 +1,8 @@
 package dk.viplev.api.adapter.inbound.rest;
 
 import dk.viplev.api.adapter.inbound.rest.dto.BenchmarkDTO;
+import dk.viplev.api.adapter.inbound.rest.dto.BenchmarkServicesPatchDTO;
+import dk.viplev.api.domain.services.BenchmarkServiceScopeService;
 import dk.viplev.api.port.inbound.BenchmarkService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +19,7 @@ import java.util.UUID;
 public class BenchmarkApiDelegateImpl implements BenchmarkApiDelegate {
 
     private final BenchmarkService benchmarkService;
+    private final BenchmarkServiceScopeService benchmarkServiceScopeService;
 
     @Override
     public ResponseEntity<List<BenchmarkDTO>> listBenchmarks(UUID environmentId) {
@@ -31,7 +34,9 @@ public class BenchmarkApiDelegateImpl implements BenchmarkApiDelegate {
 
     @Override
     public ResponseEntity<BenchmarkDTO> getBenchmark(UUID benchmarkId, UUID environmentId) {
-        return ResponseEntity.ok(benchmarkService.getBenchmark(environmentId, benchmarkId));
+        BenchmarkDTO benchmark = benchmarkService.getBenchmark(environmentId, benchmarkId);
+        benchmark.setServiceIds(benchmarkServiceScopeService.getActiveScopedServiceIds(benchmarkId));
+        return ResponseEntity.ok(benchmark);
     }
 
     @Override
@@ -42,6 +47,13 @@ public class BenchmarkApiDelegateImpl implements BenchmarkApiDelegate {
     @Override
     public ResponseEntity<Void> deleteBenchmark(UUID benchmarkId, UUID environmentId) {
         benchmarkService.deleteBenchmark(environmentId, benchmarkId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    public ResponseEntity<Void> updateBenchmarkServices(UUID environmentId, UUID benchmarkId, BenchmarkServicesPatchDTO benchmarkServicesPatchDTO) {
+        benchmarkService.getBenchmark(environmentId, benchmarkId);
+        benchmarkServiceScopeService.updateBenchmarkServices(benchmarkId, benchmarkServicesPatchDTO.getServiceIds());
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/dk/viplev/api/adapter/inbound/rest/BenchmarkApiDelegateImpl.java
+++ b/src/main/java/dk/viplev/api/adapter/inbound/rest/BenchmarkApiDelegateImpl.java
@@ -2,6 +2,7 @@ package dk.viplev.api.adapter.inbound.rest;
 
 import dk.viplev.api.adapter.inbound.rest.dto.BenchmarkDTO;
 import dk.viplev.api.adapter.inbound.rest.dto.BenchmarkServicesPatchDTO;
+import dk.viplev.api.domain.exception.BadRequestException;
 import dk.viplev.api.domain.services.BenchmarkServiceScopeService;
 import dk.viplev.api.port.inbound.BenchmarkService;
 import lombok.RequiredArgsConstructor;
@@ -52,6 +53,13 @@ public class BenchmarkApiDelegateImpl implements BenchmarkApiDelegate {
 
     @Override
     public ResponseEntity<Void> updateBenchmarkServices(UUID environmentId, UUID benchmarkId, BenchmarkServicesPatchDTO benchmarkServicesPatchDTO) {
+        if (benchmarkServicesPatchDTO == null) {
+            throw new BadRequestException("Invalid service scope", "request body must not be null");
+        }
+        if (benchmarkServicesPatchDTO.getServiceIds() == null) {
+            throw new BadRequestException("Invalid service scope", "serviceIds must not be null");
+        }
+
         benchmarkService.getBenchmark(environmentId, benchmarkId);
         benchmarkServiceScopeService.updateBenchmarkServices(benchmarkId, benchmarkServicesPatchDTO.getServiceIds());
         return ResponseEntity.noContent().build();

--- a/src/main/java/dk/viplev/api/adapter/inbound/rest/error/RestErrorHandler.java
+++ b/src/main/java/dk/viplev/api/adapter/inbound/rest/error/RestErrorHandler.java
@@ -11,6 +11,7 @@ import org.springframework.security.core.AuthenticationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -36,6 +37,21 @@ public class RestErrorHandler {
 			.type(BAD_REQUEST_TYPE_URI)
 			.title(ex.getMessage())
 			.detail(ex.getDescription())
+			.instance(URI.create(request.getRequestURI()));
+
+		return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+	}
+
+	@ExceptionHandler(HttpMessageNotReadableException.class)
+	public ResponseEntity<ErrorDTO> handleHttpMessageNotReadable(HttpMessageNotReadableException ex,
+			HttpServletRequest request) {
+		log.info("HTTP ERROR - 400 Bad Request: {}", ex.getMessage());
+
+		ErrorDTO error = new ErrorDTO()
+			.status(400)
+			.type(BAD_REQUEST_TYPE_URI)
+			.title("Bad Request")
+			.detail("Request body is invalid or missing")
 			.instance(URI.create(request.getRequestURI()));
 
 		return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);

--- a/src/main/java/dk/viplev/api/domain/services/AgentServiceImpl.java
+++ b/src/main/java/dk/viplev/api/domain/services/AgentServiceImpl.java
@@ -239,9 +239,6 @@ public class AgentServiceImpl implements AgentService {
                     if (serviceDto.getServiceName() == null || serviceDto.getServiceName().isBlank()) {
                         throw new BadRequestException("Invalid resource metrics", "serviceName must not be null or blank");
                     }
-                    if (serviceDto.getReplicas() == null) {
-                        throw new BadRequestException("Invalid resource metrics", "replicas must not be null for service " + serviceDto.getServiceName());
-                    }
                 }
 
                 Set<String> serviceNames = node.getServices().stream()

--- a/src/main/java/dk/viplev/api/domain/services/AgentServiceImpl.java
+++ b/src/main/java/dk/viplev/api/domain/services/AgentServiceImpl.java
@@ -78,6 +78,7 @@ public class AgentServiceImpl implements AgentService {
     private final BenchmarkMapper benchmarkMapper;
     private final BenchmarkRunMapper benchmarkRunMapper;
     private final MessageMapper messageMapper;
+    private final BenchmarkServiceScopeService benchmarkServiceScopeService;
 
     @Override
     @Transactional
@@ -191,6 +192,8 @@ public class AgentServiceImpl implements AgentService {
             throw new BadRequestException("Invalid resource metrics", "hosts must not be null");
         }
 
+        Set<UUID> scopedServiceIds = Set.copyOf(benchmarkServiceScopeService.getActiveScopedServiceIds(benchmarkId));
+
         int totalHostMetricDataPoints = 0;
         int totalReplicaMetricDataPoints = 0;
 
@@ -263,6 +266,12 @@ public class AgentServiceImpl implements AgentService {
                 
                 for (MetricResourceServiceDTO serviceDto : node.getServices()) {
                     Service service = servicesByName.get(serviceDto.getServiceName());
+
+                    if (!scopedServiceIds.contains(service.getId())) {
+                        log.warn("Skipping non-scoped service metrics: environmentId={}, benchmarkId={}, runId={}, serviceId={}, serviceName={}, machineId={}",
+                                environmentId, benchmarkId, runId, service.getId(), service.getServiceName(), machineId);
+                        continue;
+                    }
 
                     // Validate replicas array is not empty
                     if (serviceDto.getReplicas() == null || serviceDto.getReplicas().isEmpty()) {

--- a/src/main/java/dk/viplev/api/domain/services/BenchmarkActionServiceImpl.java
+++ b/src/main/java/dk/viplev/api/domain/services/BenchmarkActionServiceImpl.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -49,7 +50,7 @@ public class BenchmarkActionServiceImpl implements BenchmarkActionService {
         findEnvironmentByOwner(environmentId);
         Benchmark benchmark = findBenchmarkByEnvironment(benchmarkId, environmentId);
 
-        boolean hasActiveRun = benchmarkRunRepository.existsByBenchmarkIdAndStatusIn(benchmarkId, ACTIVE_STATUSES);
+        boolean hasActiveRun = benchmarkRunRepository.existsByBenchmarkIdAndStatusIn(benchmarkId, List.copyOf(ACTIVE_STATUSES));
         if (hasActiveRun) {
             throw new ConflictException("Benchmark already has an active run",
                     "Benchmark " + benchmarkId + " already has an active run");

--- a/src/main/java/dk/viplev/api/domain/services/BenchmarkRunServiceImpl.java
+++ b/src/main/java/dk/viplev/api/domain/services/BenchmarkRunServiceImpl.java
@@ -71,6 +71,7 @@ public class BenchmarkRunServiceImpl implements BenchmarkRunService {
     private final MetricK6VusRepository metricK6VusRepository;
     private final MetricResourceHostRepository metricResourceHostRepository;
     private final MetricResourceReplicaRepository metricResourceReplicaRepository;
+    private final BenchmarkServiceScopeService benchmarkServiceScopeService;
 
     @Override
     public List<BenchmarkRunDTO> listBenchmarkRuns(UUID environmentId, UUID benchmarkId) {
@@ -158,12 +159,14 @@ public class BenchmarkRunServiceImpl implements BenchmarkRunService {
         List<MetricK6Vus> vusMetrics = metricK6VusRepository.findByBenchmarkRunId(runId);
         List<MetricResourceHost> hostMetrics = metricResourceHostRepository.findByBenchmarkRunId(runId);
         List<MetricResourceReplica> replicaMetrics = metricResourceReplicaRepository.findByBenchmarkRunId(runId);
+        Set<UUID> scopedServiceIds = Set.copyOf(benchmarkServiceScopeService.getActiveScopedServiceIds(benchmarkId));
+        List<MetricResourceReplica> filteredReplicaMetrics = filterReplicaMetricsByScopedServices(replicaMetrics, scopedServiceIds);
 
         BenchmarkRunDerivedDTO result = new BenchmarkRunDerivedDTO();
         result.setRun(benchmarkRunMapper.toDto(run));
         result.setHttp(buildHttpSummaries(httpMetrics, percentileValues, percentiles));
         result.setVus(buildVusSummary(vusMetrics));
-        result.setHosts(buildHostSummaries(hostMetrics, replicaMetrics, percentileValues, percentiles));
+        result.setHosts(buildHostSummaries(hostMetrics, filteredReplicaMetrics, percentileValues, percentiles));
 
         return result;
     }
@@ -190,9 +193,11 @@ public class BenchmarkRunServiceImpl implements BenchmarkRunService {
         List<MetricResourceReplica> replicaMetrics = metricResourceReplicaRepository.findByBenchmarkRunId(runId);
         List<MetricK6Http> httpMetrics = metricK6HttpRepository.findByBenchmarkRunId(runId);
         List<MetricK6Vus> vusMetrics = metricK6VusRepository.findByBenchmarkRunId(runId);
+        Set<UUID> scopedServiceIds = Set.copyOf(benchmarkServiceScopeService.getActiveScopedServiceIds(benchmarkId));
+        List<MetricResourceReplica> filteredReplicaMetrics = filterReplicaMetricsByScopedServices(replicaMetrics, scopedServiceIds);
 
         RawTimeSeriesDTO timeSeries = new RawTimeSeriesDTO();
-        timeSeries.setHosts(buildRawHosts(hostMetrics, replicaMetrics));
+        timeSeries.setHosts(buildRawHosts(hostMetrics, filteredReplicaMetrics));
         timeSeries.setK6(buildRawK6(httpMetrics, vusMetrics));
 
         BenchmarkRunRawDTO result = new BenchmarkRunRawDTO();
@@ -700,6 +705,16 @@ public class BenchmarkRunServiceImpl implements BenchmarkRunService {
         int index = (int) Math.ceil(percentile / 100.0 * sortedValues.size()) - 1;
         index = Math.max(0, Math.min(index, sortedValues.size() - 1));
         return sortedValues.get(index);
+    }
+
+    private List<MetricResourceReplica> filterReplicaMetricsByScopedServices(List<MetricResourceReplica> replicaMetrics,
+                                                                              Set<UUID> scopedServiceIds) {
+        if (scopedServiceIds.isEmpty()) {
+            return List.of();
+        }
+        return replicaMetrics.stream()
+                .filter(metric -> scopedServiceIds.contains(metric.getReplica().getService().getId()))
+                .toList();
     }
 
     private Environment findEnvironmentByOwner(UUID environmentId) {

--- a/src/main/java/dk/viplev/api/domain/services/BenchmarkServiceScopeService.java
+++ b/src/main/java/dk/viplev/api/domain/services/BenchmarkServiceScopeService.java
@@ -1,0 +1,119 @@
+package dk.viplev.api.domain.services;
+
+import dk.viplev.api.domain.exception.BadRequestException;
+import dk.viplev.api.domain.exception.ConflictException;
+import dk.viplev.api.domain.exception.NotFoundException;
+import dk.viplev.api.domain.model.Benchmark;
+import dk.viplev.api.domain.model.BenchmarkRunStatus;
+import dk.viplev.api.domain.model.BenchmarkService;
+import dk.viplev.api.domain.model.Service;
+import dk.viplev.api.port.outbound.db.BenchmarkRepository;
+import dk.viplev.api.port.outbound.db.BenchmarkRunRepository;
+import dk.viplev.api.port.outbound.db.BenchmarkServiceRepository;
+import dk.viplev.api.port.outbound.db.ServiceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class BenchmarkServiceScopeService {
+
+    private static final List<BenchmarkRunStatus> ACTIVE_OR_PENDING_RUN_STATUSES = List.of(
+            BenchmarkRunStatus.PENDING_START,
+            BenchmarkRunStatus.STARTED,
+            BenchmarkRunStatus.PENDING_STOP
+    );
+
+    private final BenchmarkRepository benchmarkRepository;
+    private final BenchmarkServiceRepository benchmarkServiceRepository;
+    private final BenchmarkRunRepository benchmarkRunRepository;
+    private final ServiceRepository serviceRepository;
+
+    @Transactional
+    public void updateBenchmarkServices(UUID benchmarkId, List<UUID> serviceIds) {
+        if (serviceIds == null) {
+            throw new BadRequestException("Invalid service scope", "serviceIds must not be null");
+        }
+
+        validateNoDuplicates(serviceIds);
+
+        Benchmark benchmark = benchmarkRepository.findById(benchmarkId)
+                .orElseThrow(() -> new NotFoundException("Benchmark not found"));
+
+        validateAllServicesExistAndAreActiveInEnvironment(benchmark, serviceIds);
+
+        if (hasActiveOrPendingRun(benchmarkId)) {
+            throw new ConflictException("Benchmark has active or pending run",
+                    "Cannot update scoped services while benchmark run is pending or active");
+        }
+
+        Set<UUID> requested = new HashSet<>(serviceIds);
+        Set<UUID> current = new HashSet<>(getActiveScopedServiceIds(benchmarkId));
+
+        Set<UUID> toRemove = new HashSet<>(current);
+        toRemove.removeAll(requested);
+
+        Set<UUID> toAdd = new HashSet<>(requested);
+        toAdd.removeAll(current);
+
+        for (UUID serviceId : toRemove) {
+            benchmarkServiceRepository.softDeleteBenchmarkService(benchmarkId, serviceId);
+        }
+
+        for (UUID serviceId : toAdd) {
+            benchmarkServiceRepository.insertBenchmarkService(benchmarkId, serviceId);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public List<UUID> getActiveScopedServiceIds(UUID benchmarkId) {
+        return benchmarkServiceRepository.findActiveBenchmarkServices(benchmarkId).stream()
+                .map(BenchmarkService::getService)
+                .map(Service::getId)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public boolean hasActiveOrPendingRun(UUID benchmarkId) {
+        return benchmarkRunRepository.existsByBenchmarkIdAndStatusIn(benchmarkId, ACTIVE_OR_PENDING_RUN_STATUSES);
+    }
+
+    private void validateNoDuplicates(List<UUID> serviceIds) {
+        Set<UUID> unique = new HashSet<>(serviceIds);
+        if (unique.size() != serviceIds.size()) {
+            throw new BadRequestException("Duplicate service ids", "serviceIds must be unique");
+        }
+    }
+
+    private void validateAllServicesExistAndAreActiveInEnvironment(Benchmark benchmark, List<UUID> serviceIds) {
+        if (serviceIds.isEmpty()) {
+            return;
+        }
+
+        UUID environmentId = benchmark.getEnvironment().getId();
+        List<Service> activeServices = serviceRepository.findAllById(serviceIds).stream()
+                .filter(service -> service.getDeletedAt() == null)
+                .filter(service -> service.getEnvironment().getId().equals(environmentId))
+                .toList();
+
+        Set<UUID> activeServiceIds = activeServices.stream()
+                .map(Service::getId)
+                .collect(Collectors.toSet());
+
+        List<UUID> invalid = serviceIds.stream()
+                .filter(id -> !activeServiceIds.contains(id))
+                .toList();
+
+        if (!invalid.isEmpty()) {
+            throw new BadRequestException("Invalid services",
+                    "Some services do not exist, are deleted, or belong to a different environment: " + invalid);
+        }
+    }
+}

--- a/src/main/java/dk/viplev/api/domain/services/BenchmarkServiceScopeService.java
+++ b/src/main/java/dk/viplev/api/domain/services/BenchmarkServiceScopeService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashSet;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -37,12 +38,14 @@ public class BenchmarkServiceScopeService {
     private final ServiceRepository serviceRepository;
 
     @Transactional
-    public void updateBenchmarkServices(UUID benchmarkId, List<UUID> serviceIds) {
+    public void updateBenchmarkServices(UUID benchmarkId, Collection<UUID> serviceIds) {
         if (serviceIds == null) {
             throw new BadRequestException("Invalid service scope", "serviceIds must not be null");
         }
 
-        validateNoDuplicates(serviceIds);
+        List<UUID> serviceIdList = List.copyOf(serviceIds);
+
+        validateNoDuplicates(serviceIdList);
 
         Benchmark benchmark = benchmarkRepository.findById(benchmarkId)
                 .orElseThrow(() -> new NotFoundException("Benchmark not found"));
@@ -52,9 +55,9 @@ public class BenchmarkServiceScopeService {
                     "Cannot update scoped services while benchmark run is pending or active");
         }
 
-        validateAllServicesExistAndAreActiveInEnvironment(benchmark, serviceIds);
+        validateAllServicesExistAndAreActiveInEnvironment(benchmark, serviceIdList);
 
-        Set<UUID> requested = new HashSet<>(serviceIds);
+        Set<UUID> requested = new HashSet<>(serviceIdList);
         Set<UUID> current = new HashSet<>(getActiveScopedServiceIds(benchmarkId));
 
         Set<UUID> toRemove = new HashSet<>(current);

--- a/src/main/java/dk/viplev/api/domain/services/BenchmarkServiceScopeService.java
+++ b/src/main/java/dk/viplev/api/domain/services/BenchmarkServiceScopeService.java
@@ -47,12 +47,12 @@ public class BenchmarkServiceScopeService {
         Benchmark benchmark = benchmarkRepository.findById(benchmarkId)
                 .orElseThrow(() -> new NotFoundException("Benchmark not found"));
 
-        validateAllServicesExistAndAreActiveInEnvironment(benchmark, serviceIds);
-
         if (hasActiveOrPendingRun(benchmarkId)) {
             throw new ConflictException("Benchmark has active or pending run",
                     "Cannot update scoped services while benchmark run is pending or active");
         }
+
+        validateAllServicesExistAndAreActiveInEnvironment(benchmark, serviceIds);
 
         Set<UUID> requested = new HashSet<>(serviceIds);
         Set<UUID> current = new HashSet<>(getActiveScopedServiceIds(benchmarkId));

--- a/src/main/java/dk/viplev/api/port/outbound/db/BenchmarkRunRepository.java
+++ b/src/main/java/dk/viplev/api/port/outbound/db/BenchmarkRunRepository.java
@@ -9,7 +9,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -21,7 +20,7 @@ public interface BenchmarkRunRepository extends JpaRepository<BenchmarkRun, UUID
 
     Optional<BenchmarkRun> findByIdAndBenchmarkId(UUID id, UUID benchmarkId);
 
-    boolean existsByBenchmarkIdAndStatusIn(UUID benchmarkId, Collection<BenchmarkRunStatus> statuses);
+    boolean existsByBenchmarkIdAndStatusIn(UUID benchmarkId, List<BenchmarkRunStatus> statuses);
 
     Optional<BenchmarkRun> findFirstByBenchmarkEnvironmentIdAndStatusOrderByCreatedAtAsc(UUID environmentId, BenchmarkRunStatus status);
 

--- a/src/main/java/dk/viplev/api/port/outbound/db/BenchmarkServiceRepository.java
+++ b/src/main/java/dk/viplev/api/port/outbound/db/BenchmarkServiceRepository.java
@@ -7,9 +7,13 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-public interface BenchmarkServiceRepository extends JpaRepository<BenchmarkService, UUID> {
+public interface BenchmarkServiceRepository extends JpaRepository<BenchmarkService, UUID>, BenchmarkServiceRepositoryCustom {
 
     List<BenchmarkService> findByBenchmarkIdAndDeletedAtIsNull(UUID benchmarkId);
+
+    default List<BenchmarkService> findActiveBenchmarkServices(UUID benchmarkId) {
+        return findByBenchmarkIdAndDeletedAtIsNull(benchmarkId);
+    }
 
     Optional<BenchmarkService> findByBenchmarkIdAndServiceId(UUID benchmarkId, UUID serviceId);
 }

--- a/src/main/java/dk/viplev/api/port/outbound/db/BenchmarkServiceRepositoryCustom.java
+++ b/src/main/java/dk/viplev/api/port/outbound/db/BenchmarkServiceRepositoryCustom.java
@@ -1,0 +1,10 @@
+package dk.viplev.api.port.outbound.db;
+
+import java.util.UUID;
+
+public interface BenchmarkServiceRepositoryCustom {
+
+    int softDeleteBenchmarkService(UUID benchmarkId, UUID serviceId);
+
+    void insertBenchmarkService(UUID benchmarkId, UUID serviceId);
+}

--- a/src/main/java/dk/viplev/api/port/outbound/db/BenchmarkServiceRepositoryCustomImpl.java
+++ b/src/main/java/dk/viplev/api/port/outbound/db/BenchmarkServiceRepositoryCustomImpl.java
@@ -1,0 +1,45 @@
+package dk.viplev.api.port.outbound.db;
+
+import dk.viplev.api.domain.model.Benchmark;
+import dk.viplev.api.domain.model.BenchmarkService;
+import dk.viplev.api.domain.model.Service;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class BenchmarkServiceRepositoryCustomImpl implements BenchmarkServiceRepositoryCustom {
+
+    private final EntityManager entityManager;
+
+    @Override
+    @Transactional
+    public int softDeleteBenchmarkService(UUID benchmarkId, UUID serviceId) {
+        return entityManager.createNativeQuery("""
+                        UPDATE benchmark_services
+                        SET deleted_at = CURRENT_TIMESTAMP
+                        WHERE benchmark_id = :benchmarkId
+                          AND service_id = :serviceId
+                          AND deleted_at IS NULL
+                        """)
+                .setParameter("benchmarkId", benchmarkId)
+                .setParameter("serviceId", serviceId)
+                .executeUpdate();
+    }
+
+    @Override
+    @Transactional
+    public void insertBenchmarkService(UUID benchmarkId, UUID serviceId) {
+        BenchmarkService benchmarkService = new BenchmarkService();
+        benchmarkService.setBenchmark(entityManager.getReference(Benchmark.class, benchmarkId));
+        benchmarkService.setService(entityManager.getReference(Service.class, serviceId));
+        benchmarkService.setCreatedAt(LocalDateTime.now());
+        benchmarkService.setDeletedAt(null);
+        entityManager.persist(benchmarkService);
+    }
+}

--- a/src/main/resources/db/migrations/changes/027-add-benchmark-services-unique-index.sql
+++ b/src/main/resources/db/migrations/changes/027-add-benchmark-services-unique-index.sql
@@ -1,0 +1,5 @@
+-- Enforce uniqueness for active benchmark-service scopes only
+ALTER TABLE benchmark_services DROP CONSTRAINT IF EXISTS benchmark_services_benchmark_id_service_id_key;
+ALTER TABLE benchmark_services DROP CONSTRAINT IF EXISTS constraint_3;
+ALTER TABLE benchmark_services DROP CONSTRAINT IF EXISTS CONSTRAINT_INDEX_AB2;
+ALTER TABLE benchmark_services DROP CONSTRAINT IF EXISTS CONSTRAINT_AB2D;

--- a/src/main/resources/db/migrations/changes/028-add-benchmark-services-partial-unique-index.sql
+++ b/src/main/resources/db/migrations/changes/028-add-benchmark-services-partial-unique-index.sql
@@ -1,0 +1,4 @@
+-- PostgreSQL-only partial unique index for active benchmark-service links
+CREATE UNIQUE INDEX IF NOT EXISTS idx_benchmark_services_unique_active
+ON benchmark_services (benchmark_id, service_id)
+WHERE deleted_at IS NULL;

--- a/src/main/resources/db/migrations/liquibase.yaml
+++ b/src/main/resources/db/migrations/liquibase.yaml
@@ -189,3 +189,21 @@ databaseChangeLog:
         - sqlFile:
             path: changes/026-convert-byte-metrics-to-bigint.sql
             relativeToChangelogFile: true
+  - changeSet:
+      id: 27
+      author: viplev
+      changes:
+        - sqlFile:
+            path: changes/027-add-benchmark-services-unique-index.sql
+            relativeToChangelogFile: true
+  - changeSet:
+      id: 28
+      author: viplev
+      preconditions:
+        onFail: MARK_RAN
+        dbms:
+          type: postgresql
+      changes:
+        - sqlFile:
+            path: changes/028-add-benchmark-services-partial-unique-index.sql
+            relativeToChangelogFile: true

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -419,6 +419,40 @@ paths:
         '500':
           $ref: '#/components/responses/500InternalServerError'
 
+  /v1/environments/{environmentId}/benchmarks/{benchmarkId}/services:
+    patch:
+      tags:
+        - Benchmark
+      operationId: updateBenchmarkServices
+      parameters:
+        - name: environmentId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: benchmarkId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BenchmarkServicesPatchDTO'
+      responses:
+        '204':
+          description: Services updated successfully
+        '400':
+          description: Bad request (duplicate IDs, invalid services)
+        '404':
+          description: Benchmark or environment not found
+        '409':
+          description: Benchmark has active/pending run
+
 
   /v1/environments/{environmentId}/runs:
     parameters:
@@ -1045,6 +1079,23 @@ components:
           format: date-time
           readOnly: true
           description: Timestamp when benchmark was last updated
+        serviceIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          readOnly: true
+
+    BenchmarkServicesPatchDTO:
+      type: object
+      required:
+        - serviceIds
+      properties:
+        serviceIds:
+          type: array
+          items:
+            type: string
+            format: uuid
 
     PaginationDTO:
       type: object

--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -447,11 +447,15 @@ paths:
         '204':
           description: Services updated successfully
         '400':
-          description: Bad request (duplicate IDs, invalid services)
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
         '404':
-          description: Benchmark or environment not found
+          $ref: '#/components/responses/404NotFound'
         '409':
-          description: Benchmark has active/pending run
+          $ref: '#/components/responses/409Conflict'
+        '500':
+          $ref: '#/components/responses/500InternalServerError'
 
 
   /v1/environments/{environmentId}/runs:
@@ -1093,6 +1097,7 @@ components:
       properties:
         serviceIds:
           type: array
+          uniqueItems: true
           items:
             type: string
             format: uuid

--- a/src/test/java/dk/viplev/api/adapter/inbound/rest/AgentStoreResourceMetricsIT.java
+++ b/src/test/java/dk/viplev/api/adapter/inbound/rest/AgentStoreResourceMetricsIT.java
@@ -14,6 +14,7 @@ import dk.viplev.api.domain.model.Service;
 import dk.viplev.api.domain.model.User;
 import dk.viplev.api.port.outbound.db.BenchmarkRepository;
 import dk.viplev.api.port.outbound.db.BenchmarkRunRepository;
+import dk.viplev.api.port.outbound.db.BenchmarkServiceRepository;
 import dk.viplev.api.port.outbound.db.HostRepository;
 import dk.viplev.api.port.outbound.db.MetricResourceHostRepository;
 import dk.viplev.api.port.outbound.db.MetricResourceReplicaRepository;
@@ -51,6 +52,7 @@ class AgentStoreResourceMetricsIT {
     @Autowired private MetricResourceHostRepository metricResourceHostRepository;
     
     @Autowired private MetricResourceReplicaRepository metricResourceReplicaRepository;
+    @Autowired private BenchmarkServiceRepository benchmarkServiceRepository;
 
     private String environmentId;
     private String environmentToken;
@@ -75,6 +77,7 @@ class AgentStoreResourceMetricsIT {
 
         List<Service> services = serviceRepository.findByEnvironmentId(UUID.fromString(environmentId));
         serviceName = services.get(0).getServiceName();
+        benchmarkServiceRepository.insertBenchmarkService(UUID.fromString(benchmarkId), services.get(0).getId());
     }
 
     @Test
@@ -186,6 +189,58 @@ class AgentStoreResourceMetricsIT {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(metricsBody(hostMetric(machineId), null)))
                 .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void shouldIgnoreNonScopedServiceMetricsAndPersistOnlyScoped() throws Exception {
+        UUID runId = createRunDirectly(UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.STARTED);
+
+        String secondServiceName = "metrics-unscoped-" + UUID.randomUUID();
+        String payload = objectMapper.writeValueAsString(Map.of(
+                "services", List.of(
+                        Map.of(
+                                "serviceName", serviceName,
+                                "imageName", "nginx:latest",
+                                "replicas", List.of(Map.of(
+                                        "containerId", "container-" + UUID.randomUUID(),
+                                        "containerName", serviceName + "-1",
+                                        "machineId", machineId
+                                ))
+                        ),
+                        Map.of(
+                                "serviceName", secondServiceName,
+                                "imageName", "nginx:latest",
+                                "replicas", List.of(Map.of(
+                                        "containerId", "container-" + UUID.randomUUID(),
+                                        "containerName", secondServiceName + "-1",
+                                        "machineId", machineId
+                                ))
+                        )
+                ),
+                "hosts", List.of(Map.of(
+                        "name", "metrics-test-host-2",
+                        "machineId", machineId,
+                        "os", "Linux",
+                        "ipAddress", "192.168.1.101"
+                ))
+        ));
+        mockMvc.perform(post("/v1/environments/" + environmentId + "/services")
+                        .header("Authorization", "Bearer " + environmentToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isCreated());
+
+        long before = metricResourceReplicaRepository.count();
+        mockMvc.perform(post(metricsUrl(environmentId, benchmarkId, runId.toString()))
+                        .header("Authorization", "Bearer " + environmentToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(metricsBody(hostMetric(machineId), List.of(
+                                serviceMetric(serviceName),
+                                serviceMetric(secondServiceName)
+                        ))))
+                .andExpect(status().isCreated());
+
+        assertThat(metricResourceReplicaRepository.count()).isEqualTo(before + 1);
     }
 
     // --- Helpers ---

--- a/src/test/java/dk/viplev/api/adapter/inbound/rest/AgentStoreResourceMetricsIT.java
+++ b/src/test/java/dk/viplev/api/adapter/inbound/rest/AgentStoreResourceMetricsIT.java
@@ -243,6 +243,75 @@ class AgentStoreResourceMetricsIT {
         assertThat(metricResourceReplicaRepository.count()).isEqualTo(before + 1);
     }
 
+    @Test
+    void shouldIgnoreNonScopedServiceEvenWhenReplicasAreMissing() throws Exception {
+        UUID runId = createRunDirectly(UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.STARTED);
+
+        String secondServiceName = "metrics-unscoped-missing-replicas-" + UUID.randomUUID();
+        String payload = objectMapper.writeValueAsString(Map.of(
+                "services", List.of(
+                        Map.of(
+                                "serviceName", serviceName,
+                                "imageName", "nginx:latest",
+                                "replicas", List.of(Map.of(
+                                        "containerId", "container-" + UUID.randomUUID(),
+                                        "containerName", serviceName + "-1",
+                                        "machineId", machineId
+                                ))
+                        ),
+                        Map.of(
+                                "serviceName", secondServiceName,
+                                "imageName", "nginx:latest",
+                                "replicas", List.of(Map.of(
+                                        "containerId", "container-" + UUID.randomUUID(),
+                                        "containerName", secondServiceName + "-1",
+                                        "machineId", machineId
+                                ))
+                        )
+                ),
+                "hosts", List.of(Map.of(
+                        "name", "metrics-test-host-3",
+                        "machineId", machineId,
+                        "os", "Linux",
+                        "ipAddress", "192.168.1.102"
+                ))
+        ));
+        mockMvc.perform(post("/v1/environments/" + environmentId + "/services")
+                        .header("Authorization", "Bearer " + environmentToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isCreated());
+
+        long before = metricResourceReplicaRepository.count();
+        String body = objectMapper.writeValueAsString(Map.of(
+                "hosts", List.of(Map.of(
+                        "machineId", machineId,
+                        "metrics", List.of(Map.of(
+                                "collectedAt", "2025-01-15T10:00:00",
+                                "cpuPercentage", 45.5,
+                                "memoryUsageBytes", 1073741824,
+                                "memoryLimitBytes", 2147483648L,
+                                "networkInBytes", 500000,
+                                "networkOutBytes", 250000,
+                                "blockInBytes", 100000,
+                                "blockOutBytes", 50000
+                        )),
+                        "services", List.of(
+                                serviceMetric(serviceName),
+                                Map.of("serviceName", secondServiceName)
+                        )
+                ))
+        ));
+
+        mockMvc.perform(post(metricsUrl(environmentId, benchmarkId, runId.toString()))
+                        .header("Authorization", "Bearer " + environmentToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isCreated());
+
+        assertThat(metricResourceReplicaRepository.count()).isEqualTo(before + 1);
+    }
+
     // --- Helpers ---
 
     private String metricsUrl(String envId, String bmId, String runId) {

--- a/src/test/java/dk/viplev/api/adapter/inbound/rest/BenchmarkApiDelegateImplIT.java
+++ b/src/test/java/dk/viplev/api/adapter/inbound/rest/BenchmarkApiDelegateImplIT.java
@@ -1,14 +1,12 @@
 package dk.viplev.api.adapter.inbound.rest;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.util.UUID;
-
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dk.viplev.api.domain.model.BenchmarkRunStatus;
+import dk.viplev.api.port.outbound.db.BenchmarkRunRepository;
+import dk.viplev.api.port.outbound.db.BenchmarkServiceRepository;
+import dk.viplev.api.port.outbound.db.ServiceRepository;
+import dk.viplev.api.util.TestObjectFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,10 +16,19 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
-import dk.viplev.api.port.outbound.db.BenchmarkRunRepository;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -37,7 +44,13 @@ class BenchmarkApiDelegateImplIT {
     private BenchmarkRunRepository benchmarkRunRepository;
 
     @Autowired
-    private dk.viplev.api.util.TestObjectFactory testObjectFactory;
+    private ServiceRepository serviceRepository;
+
+    @Autowired
+    private BenchmarkServiceRepository benchmarkServiceRepository;
+
+    @Autowired
+    private TestObjectFactory testObjectFactory;
 
     private String user1Token;
     private String user2Token;
@@ -52,7 +65,7 @@ class BenchmarkApiDelegateImplIT {
 
     private String loginAndGetToken(String email, String password) throws Exception {
         String loginJson = objectMapper.writeValueAsString(
-                java.util.Map.of("email", email, "password", password));
+                Map.of("email", email, "password", password));
 
         MvcResult result = mockMvc.perform(post("/v1/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -66,7 +79,7 @@ class BenchmarkApiDelegateImplIT {
 
     private String createEnvironment(String token, String name, String type) throws Exception {
         String json = objectMapper.writeValueAsString(
-                java.util.Map.of("name", name, "type", type));
+                Map.of("name", name, "type", type));
 
         MvcResult result = mockMvc.perform(post("/v1/environments")
                         .header("Authorization", "Bearer " + token)
@@ -79,6 +92,14 @@ class BenchmarkApiDelegateImplIT {
                 .get("id").asText();
     }
 
+    private String getEnvironmentToken(String userToken, String environmentId) throws Exception {
+        MvcResult result = mockMvc.perform(get("/v1/environments/" + environmentId)
+                        .header("Authorization", "Bearer " + userToken))
+                .andExpect(status().isOk())
+                .andReturn();
+        return objectMapper.readTree(result.getResponse().getContentAsString()).get("token").asText();
+    }
+
     private String benchmarkUrl(String environmentId) {
         return "/v1/environments/" + environmentId + "/benchmarks";
     }
@@ -89,12 +110,36 @@ class BenchmarkApiDelegateImplIT {
 
     private String benchmarkJson(String name, String description, String k6Instructions) throws Exception {
         return objectMapper.writeValueAsString(
-                java.util.Map.of("name", name, "description", description, "k6Instructions", k6Instructions));
+                Map.of("name", name, "description", description, "k6Instructions", k6Instructions));
+    }
+
+    private String registerServicesPayload(String machineId, String... serviceNames) throws Exception {
+        List<Map<String, Object>> services = new ArrayList<>();
+        for (String serviceName : serviceNames) {
+            services.add(Map.of(
+                    "serviceName", serviceName,
+                    "imageName", "nginx:latest",
+                    "replicas", List.of(Map.of(
+                            "containerId", "container-" + UUID.randomUUID(),
+                            "containerName", serviceName + "-1",
+                            "machineId", machineId
+                    ))
+            ));
+        }
+
+        return objectMapper.writeValueAsString(Map.of(
+                "services", services,
+                "hosts", List.of(Map.of(
+                        "name", "benchmark-scope-host",
+                        "machineId", machineId,
+                        "os", "Linux",
+                        "ipAddress", "192.168.1.250"
+                ))
+        ));
     }
 
     @Test
     void shouldPerformFullCrudFlow() throws Exception {
-        // Create
         MvcResult createResult = mockMvc.perform(post(benchmarkUrl(user1EnvironmentId))
                         .header("Authorization", "Bearer " + user1Token)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -110,20 +155,17 @@ class BenchmarkApiDelegateImplIT {
         String benchmarkId = objectMapper.readTree(createResult.getResponse().getContentAsString())
                 .get("id").asText();
 
-        // List
         mockMvc.perform(get(benchmarkUrl(user1EnvironmentId))
                         .header("Authorization", "Bearer " + user1Token))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[?(@.name == 'Load Test')]").exists());
 
-        // Get
         mockMvc.perform(get(benchmarkUrl(user1EnvironmentId, benchmarkId))
                         .header("Authorization", "Bearer " + user1Token))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.name").value("Load Test"))
                 .andExpect(jsonPath("$.id").value(benchmarkId));
 
-        // Update
         mockMvc.perform(put(benchmarkUrl(user1EnvironmentId, benchmarkId))
                         .header("Authorization", "Bearer " + user1Token)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -133,12 +175,10 @@ class BenchmarkApiDelegateImplIT {
                 .andExpect(jsonPath("$.description").value("Updated desc"))
                 .andExpect(jsonPath("$.k6Instructions").value("export default function() {}"));
 
-        // Delete
         mockMvc.perform(delete(benchmarkUrl(user1EnvironmentId, benchmarkId))
                         .header("Authorization", "Bearer " + user1Token))
                 .andExpect(status().isNoContent());
 
-        // Verify gone
         mockMvc.perform(get(benchmarkUrl(user1EnvironmentId, benchmarkId))
                         .header("Authorization", "Bearer " + user1Token))
                 .andExpect(status().isNotFound());
@@ -146,7 +186,6 @@ class BenchmarkApiDelegateImplIT {
 
     @Test
     void shouldEnforceOwnership() throws Exception {
-        // User1 creates benchmark
         MvcResult createResult = mockMvc.perform(post(benchmarkUrl(user1EnvironmentId))
                         .header("Authorization", "Bearer " + user1Token)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -157,24 +196,20 @@ class BenchmarkApiDelegateImplIT {
         String benchmarkId = objectMapper.readTree(createResult.getResponse().getContentAsString())
                 .get("id").asText();
 
-        // User2 cannot list benchmarks in user1's environment
         mockMvc.perform(get(benchmarkUrl(user1EnvironmentId))
                         .header("Authorization", "Bearer " + user2Token))
                 .andExpect(status().isNotFound());
 
-        // User2 cannot get the benchmark
         mockMvc.perform(get(benchmarkUrl(user1EnvironmentId, benchmarkId))
                         .header("Authorization", "Bearer " + user2Token))
                 .andExpect(status().isNotFound());
 
-        // User2 cannot update the benchmark
         mockMvc.perform(put(benchmarkUrl(user1EnvironmentId, benchmarkId))
                         .header("Authorization", "Bearer " + user2Token)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(benchmarkJson("Hacked", "hacked", "hacked")))
                 .andExpect(status().isNotFound());
 
-        // User2 cannot delete the benchmark
         mockMvc.perform(delete(benchmarkUrl(user1EnvironmentId, benchmarkId))
                         .header("Authorization", "Bearer " + user2Token))
                 .andExpect(status().isNotFound());
@@ -189,7 +224,6 @@ class BenchmarkApiDelegateImplIT {
 
     @Test
     void shouldReturn404ForBenchmarkUnderWrongEnvironment() throws Exception {
-        // Create benchmark in user1's environment
         MvcResult createResult = mockMvc.perform(post(benchmarkUrl(user1EnvironmentId))
                         .header("Authorization", "Bearer " + user1Token)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -200,10 +234,8 @@ class BenchmarkApiDelegateImplIT {
         String benchmarkId = objectMapper.readTree(createResult.getResponse().getContentAsString())
                 .get("id").asText();
 
-        // Create a second environment for user1
         String env2Id = createEnvironment(user1Token, "Second Env", "docker");
 
-        // Try to get benchmark under wrong environment
         mockMvc.perform(get(benchmarkUrl(env2Id, benchmarkId))
                         .header("Authorization", "Bearer " + user1Token))
                 .andExpect(status().isNotFound());
@@ -237,7 +269,133 @@ class BenchmarkApiDelegateImplIT {
                         .header("Authorization", "Bearer " + user1Token))
                 .andExpect(status().isNotFound());
 
-        org.assertj.core.api.Assertions.assertThat(benchmarkRunRepository.findByBenchmarkId(UUID.fromString(bmId)))
-                .isEmpty();
+        assertThat(benchmarkRunRepository.findByBenchmarkId(UUID.fromString(bmId))).isEmpty();
+    }
+
+    @Test
+    void shouldPatchBenchmarkServicesScopeAndExposeServiceIdsOnGet() throws Exception {
+        MvcResult createResult = mockMvc.perform(post(benchmarkUrl(user1EnvironmentId))
+                        .header("Authorization", "Bearer " + user1Token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(benchmarkJson("Scoped Benchmark", "desc", "script")))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        String benchmarkId = objectMapper.readTree(createResult.getResponse().getContentAsString()).get("id").asText();
+
+        String machineId = "scope-machine-" + UUID.randomUUID();
+        mockMvc.perform(post("/v1/environments/" + user1EnvironmentId + "/services")
+                        .header("Authorization", "Bearer " + getEnvironmentToken(user1Token, user1EnvironmentId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(registerServicesPayload(machineId, "svc-a-" + UUID.randomUUID(), "svc-b-" + UUID.randomUUID())))
+                .andExpect(status().isCreated());
+
+        var services = serviceRepository.findByEnvironmentIdAndDeletedAtIsNull(UUID.fromString(user1EnvironmentId));
+        UUID serviceA = services.get(0).getId();
+        UUID serviceB = services.get(1).getId();
+
+        String patchBody = objectMapper.writeValueAsString(Map.of("serviceIds", List.of(serviceA, serviceB)));
+
+        mockMvc.perform(patch(benchmarkUrl(user1EnvironmentId, benchmarkId) + "/services")
+                        .header("Authorization", "Bearer " + user1Token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(patchBody))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get(benchmarkUrl(user1EnvironmentId, benchmarkId))
+                        .header("Authorization", "Bearer " + user1Token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.serviceIds.length()").value(2));
+    }
+
+    @Test
+    void shouldReturn409WhenPatchingServicesWithActiveRun() throws Exception {
+        MvcResult createResult = mockMvc.perform(post(benchmarkUrl(user1EnvironmentId))
+                        .header("Authorization", "Bearer " + user1Token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(benchmarkJson("Conflict Benchmark", "desc", "script")))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        String benchmarkId = objectMapper.readTree(createResult.getResponse().getContentAsString()).get("id").asText();
+        testObjectFactory.createBenchmarkRunDirectly(UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.STARTED);
+
+        String patchBody = objectMapper.writeValueAsString(Map.of("serviceIds", List.of()));
+        mockMvc.perform(patch(benchmarkUrl(user1EnvironmentId, benchmarkId) + "/services")
+                        .header("Authorization", "Bearer " + user1Token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(patchBody))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void shouldReturn400ForInvalidOrDuplicateServiceIdsWhenPatchingServices() throws Exception {
+        MvcResult createResult = mockMvc.perform(post(benchmarkUrl(user1EnvironmentId))
+                        .header("Authorization", "Bearer " + user1Token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(benchmarkJson("Invalid Scope Benchmark", "desc", "script")))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        String benchmarkId = objectMapper.readTree(createResult.getResponse().getContentAsString()).get("id").asText();
+
+        UUID randomServiceId = UUID.randomUUID();
+        String invalidBody = objectMapper.writeValueAsString(Map.of("serviceIds", List.of(randomServiceId)));
+        mockMvc.perform(patch(benchmarkUrl(user1EnvironmentId, benchmarkId) + "/services")
+                        .header("Authorization", "Bearer " + user1Token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(invalidBody))
+                .andExpect(status().isBadRequest());
+
+        String duplicateBody = objectMapper.writeValueAsString(Map.of("serviceIds", List.of(randomServiceId, randomServiceId)));
+        mockMvc.perform(patch(benchmarkUrl(user1EnvironmentId, benchmarkId) + "/services")
+                        .header("Authorization", "Bearer " + user1Token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(duplicateBody))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldCreateNewRowWhenReAddingPreviouslyRemovedService() throws Exception {
+        MvcResult createResult = mockMvc.perform(post(benchmarkUrl(user1EnvironmentId))
+                        .header("Authorization", "Bearer " + user1Token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(benchmarkJson("Readd Benchmark", "desc", "script")))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        String benchmarkId = objectMapper.readTree(createResult.getResponse().getContentAsString()).get("id").asText();
+        String machineId = "readd-machine-" + UUID.randomUUID();
+        mockMvc.perform(post("/v1/environments/" + user1EnvironmentId + "/services")
+                        .header("Authorization", "Bearer " + getEnvironmentToken(user1Token, user1EnvironmentId))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(registerServicesPayload(machineId, "svc-readd-" + UUID.randomUUID())))
+                .andExpect(status().isCreated());
+
+        UUID serviceId = serviceRepository.findByEnvironmentIdAndDeletedAtIsNull(UUID.fromString(user1EnvironmentId)).getFirst().getId();
+
+        String addBody = objectMapper.writeValueAsString(Map.of("serviceIds", List.of(serviceId)));
+        String removeBody = objectMapper.writeValueAsString(Map.of("serviceIds", List.of()));
+
+        mockMvc.perform(patch(benchmarkUrl(user1EnvironmentId, benchmarkId) + "/services")
+                        .header("Authorization", "Bearer " + user1Token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(addBody))
+                .andExpect(status().isNoContent());
+        mockMvc.perform(patch(benchmarkUrl(user1EnvironmentId, benchmarkId) + "/services")
+                        .header("Authorization", "Bearer " + user1Token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(removeBody))
+                .andExpect(status().isNoContent());
+        mockMvc.perform(patch(benchmarkUrl(user1EnvironmentId, benchmarkId) + "/services")
+                        .header("Authorization", "Bearer " + user1Token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(addBody))
+                .andExpect(status().isNoContent());
+
+        assertThat(benchmarkServiceRepository.findAll().stream()
+                .filter(bs -> bs.getBenchmark().getId().equals(UUID.fromString(benchmarkId)))
+                .filter(bs -> bs.getService().getId().equals(serviceId)))
+                .hasSize(2);
     }
 }

--- a/src/test/java/dk/viplev/api/adapter/inbound/rest/BenchmarkApiDelegateImplIT.java
+++ b/src/test/java/dk/viplev/api/adapter/inbound/rest/BenchmarkApiDelegateImplIT.java
@@ -356,6 +356,43 @@ class BenchmarkApiDelegateImplIT {
     }
 
     @Test
+    void shouldReturn409EvenWhenServiceIdsAreInvalidIfRunIsActive() throws Exception {
+        MvcResult createResult = mockMvc.perform(post(benchmarkUrl(user1EnvironmentId))
+                        .header("Authorization", "Bearer " + user1Token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(benchmarkJson("Conflict Priority Benchmark", "desc", "script")))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        String benchmarkId = objectMapper.readTree(createResult.getResponse().getContentAsString()).get("id").asText();
+        testObjectFactory.createBenchmarkRunDirectly(UUID.fromString(benchmarkId), "user1@viplev.dk", BenchmarkRunStatus.STARTED);
+
+        String invalidBody = objectMapper.writeValueAsString(Map.of("serviceIds", List.of(UUID.randomUUID())));
+        mockMvc.perform(patch(benchmarkUrl(user1EnvironmentId, benchmarkId) + "/services")
+                        .header("Authorization", "Bearer " + user1Token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(invalidBody))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void shouldReturn400WhenPatchRequestBodyIsMissing() throws Exception {
+        MvcResult createResult = mockMvc.perform(post(benchmarkUrl(user1EnvironmentId))
+                        .header("Authorization", "Bearer " + user1Token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(benchmarkJson("Missing ServiceIds Benchmark", "desc", "script")))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        String benchmarkId = objectMapper.readTree(createResult.getResponse().getContentAsString()).get("id").asText();
+
+        mockMvc.perform(patch(benchmarkUrl(user1EnvironmentId, benchmarkId) + "/services")
+                        .header("Authorization", "Bearer " + user1Token)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
     void shouldCreateNewRowWhenReAddingPreviouslyRemovedService() throws Exception {
         MvcResult createResult = mockMvc.perform(post(benchmarkUrl(user1EnvironmentId))
                         .header("Authorization", "Bearer " + user1Token)

--- a/src/test/java/dk/viplev/api/adapter/inbound/rest/BenchmarkRunDerivedIT.java
+++ b/src/test/java/dk/viplev/api/adapter/inbound/rest/BenchmarkRunDerivedIT.java
@@ -20,6 +20,7 @@ import dk.viplev.api.domain.model.Service;
 import dk.viplev.api.domain.model.User;
 import dk.viplev.api.port.outbound.db.BenchmarkRepository;
 import dk.viplev.api.port.outbound.db.BenchmarkRunRepository;
+import dk.viplev.api.port.outbound.db.BenchmarkServiceRepository;
 import dk.viplev.api.port.outbound.db.HostRepository;
 import dk.viplev.api.port.outbound.db.MetricK6HttpRepository;
 import dk.viplev.api.port.outbound.db.MetricK6VusRepository;
@@ -58,6 +59,7 @@ class BenchmarkRunDerivedIT {
     @Autowired private MetricResourceHostRepository metricResourceHostRepository;
     @Autowired private MetricResourceReplicaRepository metricResourceReplicaRepository;
     @Autowired private ServiceReplicaRepository serviceReplicaRepository;
+    @Autowired private BenchmarkServiceRepository benchmarkServiceRepository;
 
     private String user1Token;
     private String user2Token;
@@ -85,6 +87,7 @@ class BenchmarkRunDerivedIT {
 
         List<Service> services = serviceRepository.findByEnvironmentId(UUID.fromString(environmentId));
         service = services.get(0);
+        benchmarkServiceRepository.insertBenchmarkService(UUID.fromString(benchmarkId), service.getId());
         
         // Create a replica for the service
         // Use unique container ID to avoid conflicts across tests (global uniqueness constraint)
@@ -265,6 +268,38 @@ class BenchmarkRunDerivedIT {
 
         mockMvc.perform(get(runUrl(environmentId, benchmarkId, run.getId().toString())))
                 .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void shouldReturnOnlyScopedServiceMetricsAndKeepHostAndK6ForDerived() throws Exception {
+        BenchmarkRun run = createRunDirectly(UUID.fromString(benchmarkId), "user1@viplev.dk");
+        LocalDateTime t = LocalDateTime.of(2025, 1, 15, 12, 0, 0);
+
+        Service unscopedService = new Service();
+        unscopedService.setEnvironment(service.getEnvironment());
+        unscopedService.setServiceName("derived-unscoped-" + UUID.randomUUID());
+        unscopedService = serviceRepository.saveAndFlush(unscopedService);
+        ServiceReplica unscopedReplica = new ServiceReplica();
+        unscopedReplica.setService(unscopedService);
+        unscopedReplica.setHost(host);
+        unscopedReplica.setContainerId("derived-unscoped-container-" + UUID.randomUUID());
+        unscopedReplica.setContainerName("derived-unscoped-container");
+        unscopedReplica.setStartedAt(LocalDateTime.now());
+        unscopedReplica.setLastSeenAt(LocalDateTime.now());
+        unscopedReplica = serviceReplicaRepository.saveAndFlush(unscopedReplica);
+
+        metricResourceHostRepository.saveAndFlush(new MetricResourceHost(run, host, t, 10.0, 1L, 2L, 3L, 4L, 5L, 6L));
+        metricResourceReplicaRepository.saveAndFlush(new MetricResourceReplica(run, replica, t, 20.0, 10L, 20L, 30L, 40L, 50L, 60L));
+        metricResourceReplicaRepository.saveAndFlush(new MetricResourceReplica(run, unscopedReplica, t, 99.0, 10L, 20L, 30L, 40L, 50L, 60L));
+        metricK6HttpRepository.saveAndFlush(new MetricK6Http(run, t, "http://test", "GET", "g", 200, 200, 1, 1, 11, 7));
+
+        mockMvc.perform(get(runUrl(environmentId, benchmarkId, run.getId().toString()))
+                        .header("Authorization", "Bearer " + user1Token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.hosts.length()").value(1))
+                .andExpect(jsonPath("$.hosts[0].services.length()").value(1))
+                .andExpect(jsonPath("$.hosts[0].services[0].serviceId").value(service.getId().toString()))
+                .andExpect(jsonPath("$.http.length()").value(1));
     }
 
     // --- Helpers ---

--- a/src/test/java/dk/viplev/api/adapter/inbound/rest/BenchmarkRunRawIT.java
+++ b/src/test/java/dk/viplev/api/adapter/inbound/rest/BenchmarkRunRawIT.java
@@ -20,6 +20,7 @@ import dk.viplev.api.domain.model.ServiceReplica;
 import dk.viplev.api.domain.model.User;
 import dk.viplev.api.port.outbound.db.BenchmarkRepository;
 import dk.viplev.api.port.outbound.db.BenchmarkRunRepository;
+import dk.viplev.api.port.outbound.db.BenchmarkServiceRepository;
 import dk.viplev.api.port.outbound.db.HostRepository;
 import dk.viplev.api.port.outbound.db.MetricK6HttpRepository;
 import dk.viplev.api.port.outbound.db.MetricK6VusRepository;
@@ -58,6 +59,7 @@ class BenchmarkRunRawIT {
     @Autowired private MetricK6VusRepository metricK6VusRepository;
     @Autowired private MetricResourceHostRepository metricResourceHostRepository;
     @Autowired private MetricResourceReplicaRepository metricResourceReplicaRepository;
+    @Autowired private BenchmarkServiceRepository benchmarkServiceRepository;
 
     private String user1Token;
     private String user2Token;
@@ -85,6 +87,7 @@ class BenchmarkRunRawIT {
 
         List<Service> services = serviceRepository.findByEnvironmentId(UUID.fromString(environmentId));
         service = services.get(0);
+        benchmarkServiceRepository.insertBenchmarkService(UUID.fromString(benchmarkId), service.getId());
         
         // Create a replica for the service
         // Use unique container ID to avoid conflicts across tests (global uniqueness constraint)
@@ -197,6 +200,39 @@ class BenchmarkRunRawIT {
 
         mockMvc.perform(get(rawUrl(environmentId, benchmarkId, run.getId().toString())))
                 .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void shouldReturnOnlyScopedServiceMetricsAndKeepHostAndK6() throws Exception {
+        BenchmarkRun run = createRunDirectly(UUID.fromString(benchmarkId), "user1@viplev.dk");
+        LocalDateTime t = LocalDateTime.of(2025, 1, 15, 11, 0, 0);
+
+        Service unscopedService = new Service();
+        unscopedService.setEnvironment(service.getEnvironment());
+        unscopedService.setServiceName("raw-unscoped-" + UUID.randomUUID());
+        unscopedService = serviceRepository.saveAndFlush(unscopedService);
+        ServiceReplica unscopedReplica = new ServiceReplica();
+        unscopedReplica.setService(unscopedService);
+        unscopedReplica.setHost(host);
+        unscopedReplica.setContainerId("raw-unscoped-container-" + UUID.randomUUID());
+        unscopedReplica.setContainerName("raw-unscoped-container");
+        unscopedReplica.setStartedAt(LocalDateTime.now());
+        unscopedReplica.setLastSeenAt(LocalDateTime.now());
+        unscopedReplica = serviceReplicaRepository.saveAndFlush(unscopedReplica);
+
+        metricResourceHostRepository.saveAndFlush(new MetricResourceHost(run, host, t, 10.0, 1L, 2L, 3L, 4L, 5L, 6L));
+        metricResourceReplicaRepository.saveAndFlush(new MetricResourceReplica(run, replica, t, 20.0, 10L, 20L, 30L, 40L, 50L, 60L));
+        metricResourceReplicaRepository.saveAndFlush(new MetricResourceReplica(run, unscopedReplica, t, 99.0, 10L, 20L, 30L, 40L, 50L, 60L));
+        metricK6HttpRepository.saveAndFlush(new MetricK6Http(run, t, "http://test", "GET", "g", 200, 200, 1, 1, 11, 7));
+
+        mockMvc.perform(get(rawUrl(environmentId, benchmarkId, run.getId().toString()))
+                        .header("Authorization", "Bearer " + user1Token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.timeSeries.hosts.length()").value(1))
+                .andExpect(jsonPath("$.timeSeries.hosts[0].dataPoints.length()").value(1))
+                .andExpect(jsonPath("$.timeSeries.hosts[0].services.length()").value(1))
+                .andExpect(jsonPath("$.timeSeries.hosts[0].services[0].serviceId").value(service.getId().toString()))
+                .andExpect(jsonPath("$.timeSeries.k6.dataPoints.length()").value(1));
     }
 
     // --- Helpers ---

--- a/src/test/java/dk/viplev/api/domain/services/AgentServiceImplTest.java
+++ b/src/test/java/dk/viplev/api/domain/services/AgentServiceImplTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.lenient;
 
 import dk.viplev.api.adapter.inbound.rest.dto.MetricDataPointDTO;
 import dk.viplev.api.adapter.inbound.rest.dto.MetricResourceDTO;
@@ -64,6 +65,7 @@ class AgentServiceImplTest {
     @Mock private BenchmarkMapper benchmarkMapper;
     @Mock private BenchmarkRunMapper benchmarkRunMapper;
     @Mock private MessageMapper messageMapper;
+    @Mock private BenchmarkServiceScopeService benchmarkServiceScopeService;
 
     private AgentServiceImpl agentService;
 
@@ -82,7 +84,9 @@ class AgentServiceImplTest {
                 metricResourceReplicaRepository,
                 metricK6HttpRepository, metricK6VusRepository,
                 environmentRepository,
-                authService, benchmarkMapper, benchmarkRunMapper, messageMapper);
+                authService, benchmarkMapper, benchmarkRunMapper, messageMapper, benchmarkServiceScopeService);
+
+        lenient().when(benchmarkServiceScopeService.getActiveScopedServiceIds(benchmarkId)).thenReturn(List.of());
 
         activeRun = new BenchmarkRun();
         activeRun.setId(runId);
@@ -171,6 +175,7 @@ class AgentServiceImplTest {
         Service svc = new Service();
         svc.setId(UUID.randomUUID());
         svc.setServiceName("my-service");
+        when(benchmarkServiceScopeService.getActiveScopedServiceIds(benchmarkId)).thenReturn(List.of(svc.getId()));
         when(serviceRepository.findByEnvironmentIdAndServiceNameInAndDeletedAtIsNull(eq(environmentId), anySet()))
                 .thenReturn(List.of(svc));
         
@@ -504,6 +509,7 @@ class AgentServiceImplTest {
         dk.viplev.api.domain.model.Service svc = new dk.viplev.api.domain.model.Service();
         svc.setId(UUID.randomUUID());
         svc.setServiceName("my-service");
+        when(benchmarkServiceScopeService.getActiveScopedServiceIds(benchmarkId)).thenReturn(List.of(svc.getId()));
         when(serviceRepository.findByEnvironmentIdAndServiceNameInAndDeletedAtIsNull(eq(environmentId), anySet()))
                 .thenReturn(List.of(svc));
 

--- a/src/test/java/dk/viplev/api/domain/services/AgentServiceImplTest.java
+++ b/src/test/java/dk/viplev/api/domain/services/AgentServiceImplTest.java
@@ -459,6 +459,13 @@ class AgentServiceImplTest {
                 .thenReturn(Optional.of(host));
         when(metricResourceHostRepository.saveAll(any())).thenReturn(List.of());
 
+        Service svc = new Service();
+        svc.setId(UUID.randomUUID());
+        svc.setServiceName("my-service");
+        when(benchmarkServiceScopeService.getActiveScopedServiceIds(benchmarkId)).thenReturn(List.of(svc.getId()));
+        when(serviceRepository.findByEnvironmentIdAndServiceNameInAndDeletedAtIsNull(eq(environmentId), anySet()))
+                .thenReturn(List.of(svc));
+
         MetricResourceServiceDTO serviceDto = new MetricResourceServiceDTO();
         serviceDto.setServiceName("my-service");
         serviceDto.setReplicas(null);

--- a/src/test/java/dk/viplev/api/domain/services/BenchmarkServiceScopeServiceTest.java
+++ b/src/test/java/dk/viplev/api/domain/services/BenchmarkServiceScopeServiceTest.java
@@ -1,0 +1,169 @@
+package dk.viplev.api.domain.services;
+
+import dk.viplev.api.domain.exception.BadRequestException;
+import dk.viplev.api.domain.exception.ConflictException;
+import dk.viplev.api.domain.model.Benchmark;
+import dk.viplev.api.domain.model.BenchmarkRunStatus;
+import dk.viplev.api.domain.model.BenchmarkService;
+import dk.viplev.api.domain.model.Environment;
+import dk.viplev.api.domain.model.Service;
+import dk.viplev.api.port.outbound.db.BenchmarkRepository;
+import dk.viplev.api.port.outbound.db.BenchmarkRunRepository;
+import dk.viplev.api.port.outbound.db.BenchmarkServiceRepository;
+import dk.viplev.api.port.outbound.db.ServiceRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BenchmarkServiceScopeServiceTest {
+
+    @Mock
+    private BenchmarkRepository benchmarkRepository;
+    @Mock
+    private BenchmarkServiceRepository benchmarkServiceRepository;
+    @Mock
+    private BenchmarkRunRepository benchmarkRunRepository;
+    @Mock
+    private ServiceRepository serviceRepository;
+
+    private BenchmarkServiceScopeService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new BenchmarkServiceScopeService(
+                benchmarkRepository,
+                benchmarkServiceRepository,
+                benchmarkRunRepository,
+                serviceRepository
+        );
+    }
+
+    @Test
+    void shouldReplaceScopeWithAddRemoveAndReAdd() {
+        UUID benchmarkId = UUID.randomUUID();
+        UUID envId = UUID.randomUUID();
+        UUID serviceA = UUID.randomUUID();
+        UUID serviceB = UUID.randomUUID();
+        UUID serviceC = UUID.randomUUID();
+
+        Benchmark benchmark = benchmark(envId);
+        when(benchmarkRepository.findById(benchmarkId)).thenReturn(Optional.of(benchmark));
+        when(benchmarkRunRepository.existsByBenchmarkIdAndStatusIn(any(), any())).thenReturn(false);
+        when(serviceRepository.findAllById(List.of(serviceA, serviceC))).thenReturn(List.of(activeService(serviceA, envId), activeService(serviceC, envId)));
+        when(benchmarkServiceRepository.findActiveBenchmarkServices(benchmarkId)).thenReturn(List.of(link(serviceA), link(serviceB)));
+
+        service.updateBenchmarkServices(benchmarkId, List.of(serviceA, serviceC));
+
+        verify(benchmarkServiceRepository).softDeleteBenchmarkService(benchmarkId, serviceB);
+        verify(benchmarkServiceRepository).insertBenchmarkService(benchmarkId, serviceC);
+
+        when(serviceRepository.findAllById(List.of(serviceA, serviceB))).thenReturn(List.of(activeService(serviceA, envId), activeService(serviceB, envId)));
+        when(benchmarkServiceRepository.findActiveBenchmarkServices(benchmarkId)).thenReturn(List.of(link(serviceA), link(serviceC)));
+
+        service.updateBenchmarkServices(benchmarkId, List.of(serviceA, serviceB));
+
+        verify(benchmarkServiceRepository).softDeleteBenchmarkService(benchmarkId, serviceC);
+        verify(benchmarkServiceRepository).insertBenchmarkService(benchmarkId, serviceB);
+    }
+
+    @Test
+    void shouldRejectDuplicateServiceIds() {
+        UUID benchmarkId = UUID.randomUUID();
+        UUID serviceId = UUID.randomUUID();
+
+        assertThatThrownBy(() -> service.updateBenchmarkServices(benchmarkId, List.of(serviceId, serviceId)))
+                .isInstanceOf(BadRequestException.class);
+
+        verify(benchmarkRepository, never()).findById(any());
+    }
+
+    @Test
+    void shouldRejectInvalidOrDeletedOrForeignServices() {
+        UUID benchmarkId = UUID.randomUUID();
+        UUID envId = UUID.randomUUID();
+        UUID validId = UUID.randomUUID();
+        UUID deletedId = UUID.randomUUID();
+        UUID foreignId = UUID.randomUUID();
+
+        Benchmark benchmark = benchmark(envId);
+        when(benchmarkRepository.findById(benchmarkId)).thenReturn(Optional.of(benchmark));
+        when(serviceRepository.findAllById(List.of(validId, deletedId, foreignId))).thenReturn(List.of(
+                activeService(validId, envId),
+                deletedService(deletedId, envId),
+                activeService(foreignId, UUID.randomUUID())
+        ));
+
+        assertThatThrownBy(() -> service.updateBenchmarkServices(benchmarkId, List.of(validId, deletedId, foreignId)))
+                .isInstanceOf(BadRequestException.class);
+    }
+
+    @Test
+    void shouldRejectUpdateWhenRunIsActiveOrPending() {
+        UUID benchmarkId = UUID.randomUUID();
+        UUID envId = UUID.randomUUID();
+        UUID serviceId = UUID.randomUUID();
+
+        Benchmark benchmark = benchmark(envId);
+        when(benchmarkRepository.findById(benchmarkId)).thenReturn(Optional.of(benchmark));
+        when(serviceRepository.findAllById(List.of(serviceId))).thenReturn(List.of(activeService(serviceId, envId)));
+        when(benchmarkRunRepository.existsByBenchmarkIdAndStatusIn(any(), any())).thenReturn(true);
+
+        assertThatThrownBy(() -> service.updateBenchmarkServices(benchmarkId, List.of(serviceId)))
+                .isInstanceOf(ConflictException.class);
+
+        verify(benchmarkServiceRepository, never()).softDeleteBenchmarkService(any(), any());
+        verify(benchmarkServiceRepository, never()).insertBenchmarkService(any(), any());
+
+        ArgumentCaptor<List<BenchmarkRunStatus>> statusesCaptor = ArgumentCaptor.forClass(List.class);
+        verify(benchmarkRunRepository).existsByBenchmarkIdAndStatusIn(org.mockito.ArgumentMatchers.eq(benchmarkId), statusesCaptor.capture());
+        assertThat(statusesCaptor.getValue())
+                .containsExactlyInAnyOrder(BenchmarkRunStatus.PENDING_START, BenchmarkRunStatus.STARTED, BenchmarkRunStatus.PENDING_STOP);
+    }
+
+    private Benchmark benchmark(UUID environmentId) {
+        Environment environment = new Environment();
+        environment.setId(environmentId);
+        Benchmark benchmark = new Benchmark();
+        benchmark.setId(UUID.randomUUID());
+        benchmark.setEnvironment(environment);
+        return benchmark;
+    }
+
+    private Service activeService(UUID id, UUID environmentId) {
+        Service service = new Service();
+        service.setId(id);
+        Environment environment = new Environment();
+        environment.setId(environmentId);
+        service.setEnvironment(environment);
+        return service;
+    }
+
+    private Service deletedService(UUID id, UUID environmentId) {
+        Service service = activeService(id, environmentId);
+        service.setDeletedAt(java.time.LocalDateTime.now());
+        return service;
+    }
+
+    private BenchmarkService link(UUID serviceId) {
+        Service service = new Service();
+        service.setId(serviceId);
+        BenchmarkService link = new BenchmarkService();
+        link.setService(service);
+        return link;
+    }
+}

--- a/src/test/java/dk/viplev/api/domain/services/BenchmarkServiceScopeServiceTest.java
+++ b/src/test/java/dk/viplev/api/domain/services/BenchmarkServiceScopeServiceTest.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -120,12 +121,12 @@ class BenchmarkServiceScopeServiceTest {
 
         Benchmark benchmark = benchmark(envId);
         when(benchmarkRepository.findById(benchmarkId)).thenReturn(Optional.of(benchmark));
-        when(serviceRepository.findAllById(List.of(serviceId))).thenReturn(List.of(activeService(serviceId, envId)));
         when(benchmarkRunRepository.existsByBenchmarkIdAndStatusIn(any(), any())).thenReturn(true);
 
         assertThatThrownBy(() -> service.updateBenchmarkServices(benchmarkId, List.of(serviceId)))
                 .isInstanceOf(ConflictException.class);
 
+        verifyNoInteractions(serviceRepository);
         verify(benchmarkServiceRepository, never()).softDeleteBenchmarkService(any(), any());
         verify(benchmarkServiceRepository, never()).insertBenchmarkService(any(), any());
 
@@ -133,6 +134,24 @@ class BenchmarkServiceScopeServiceTest {
         verify(benchmarkRunRepository).existsByBenchmarkIdAndStatusIn(org.mockito.ArgumentMatchers.eq(benchmarkId), statusesCaptor.capture());
         assertThat(statusesCaptor.getValue())
                 .containsExactlyInAnyOrder(BenchmarkRunStatus.PENDING_START, BenchmarkRunStatus.STARTED, BenchmarkRunStatus.PENDING_STOP);
+    }
+
+    @Test
+    void shouldPrioritizeConflictOverInvalidServicesWhenRunIsActive() {
+        UUID benchmarkId = UUID.randomUUID();
+        UUID envId = UUID.randomUUID();
+        UUID invalidServiceId = UUID.randomUUID();
+
+        Benchmark benchmark = benchmark(envId);
+        when(benchmarkRepository.findById(benchmarkId)).thenReturn(Optional.of(benchmark));
+        when(benchmarkRunRepository.existsByBenchmarkIdAndStatusIn(any(), any())).thenReturn(true);
+
+        assertThatThrownBy(() -> service.updateBenchmarkServices(benchmarkId, List.of(invalidServiceId)))
+                .isInstanceOf(ConflictException.class);
+
+        verifyNoInteractions(serviceRepository);
+        verify(benchmarkServiceRepository, never()).softDeleteBenchmarkService(any(), any());
+        verify(benchmarkServiceRepository, never()).insertBenchmarkService(any(), any());
     }
 
     private Benchmark benchmark(UUID environmentId) {


### PR DESCRIPTION
## Summary
- add API support for benchmark service scoping via `PATCH /v1/environments/{environmentId}/benchmarks/{benchmarkId}/services`
- enforce scoped service validation and conflict guards in domain/repository logic with supporting migrations and partial unique index
- filter metric ingest and raw/derived benchmark run reads to include only explicitly scoped services, with unit/integration test coverage

Closes #63