### PR TITLE
fix(agent_command): agent run command returned by environment read API (#49)

### DIFF
--- a/src/main/java/dk/viplev/api/adapter/inbound/rest/mapper/EnvironmentMapper.java
+++ b/src/main/java/dk/viplev/api/adapter/inbound/rest/mapper/EnvironmentMapper.java
@@ -22,15 +22,18 @@ public interface EnvironmentMapper {
     default String toAgentCommand(Environment environment) {
         return switch (environment.getType()) {
             case "docker" -> "docker run -d"
+                    + " --pull always"
+                    + " --restart unless-stopped"
                     + " --name viplev-agent"
-                    + " -v /var/run/docker.sock:/var/run/docker.sock"
-                    + " -v /proc:/host/proc:ro"
-                    + " -v /etc/machine-id:/etc/machine-id:ro"
                     + " -e VIPLEV_URL=https://api.viplev.ringhus.dk"
                     + " -e VIPLEV_TOKEN=" + environment.getToken()
                     + " -e VIPLEV_ENVIRONMENT_ID=" + environment.getId()
-                    + " -e AGENT_PROC_PATH=/host/proc"
-                    + " -p 8080:8080"
+                    + " -e VIPLEV_CADVISOR_IMAGE=gcr.io/cadvisor/cadvisor:v0.51.0"
+                    + " -e VIPLEV_NODE_EXPORTER_IMAGE=prom/node-exporter:v1.9.0"
+                    + " -e VIPLEV_K6_IMAGE=grafana/k6:0.53.0"
+                    + " -e VIPLEV_K6_TIMEOUT_MS=300000"
+                    + " -e AGENT_MESSAGE_POLLING_ENABLED=false"
+                    + " -v /var/run/docker.sock:/var/run/docker.sock"
                     + " ghcr.io/viplev/agent:latest";
             case "kubernetes" -> "kubectl apply -f - # VIPLEV_TOKEN=" + environment.getToken();
             default -> "";

--- a/src/test/java/dk/viplev/api/adapter/inbound/rest/EnvironmentApiDelegateImplIT.java
+++ b/src/test/java/dk/viplev/api/adapter/inbound/rest/EnvironmentApiDelegateImplIT.java
@@ -298,15 +298,18 @@ class EnvironmentApiDelegateImplIT {
 
         org.assertj.core.api.Assertions.assertThat(agentCommand)
                 .isEqualTo("docker run -d"
+                        + " --pull always"
+                        + " --restart unless-stopped"
                         + " --name viplev-agent"
-                        + " -v /var/run/docker.sock:/var/run/docker.sock"
-                        + " -v /proc:/host/proc:ro"
-                        + " -v /etc/machine-id:/etc/machine-id:ro"
                         + " -e VIPLEV_URL=https://api.viplev.ringhus.dk"
                         + " -e VIPLEV_TOKEN=" + token
                         + " -e VIPLEV_ENVIRONMENT_ID=" + id
-                        + " -e AGENT_PROC_PATH=/host/proc"
-                        + " -p 8080:8080"
+                        + " -e VIPLEV_CADVISOR_IMAGE=gcr.io/cadvisor/cadvisor:v0.51.0"
+                        + " -e VIPLEV_NODE_EXPORTER_IMAGE=prom/node-exporter:v1.9.0"
+                        + " -e VIPLEV_K6_IMAGE=grafana/k6:0.53.0"
+                        + " -e VIPLEV_K6_TIMEOUT_MS=300000"
+                        + " -e AGENT_MESSAGE_POLLING_ENABLED=false"
+                        + " -v /var/run/docker.sock:/var/run/docker.sock"
                         + " ghcr.io/viplev/agent:latest");
     }
 }

--- a/src/test/java/dk/viplev/api/domain/services/EnvironmentServiceImplTest.java
+++ b/src/test/java/dk/viplev/api/domain/services/EnvironmentServiceImplTest.java
@@ -176,15 +176,18 @@ class EnvironmentServiceImplTest {
 
         assertThat(result.getAgentCommand())
                 .isEqualTo("docker run -d"
+                        + " --pull always"
+                        + " --restart unless-stopped"
                         + " --name viplev-agent"
-                        + " -v /var/run/docker.sock:/var/run/docker.sock"
-                        + " -v /proc:/host/proc:ro"
-                        + " -v /etc/machine-id:/etc/machine-id:ro"
                         + " -e VIPLEV_URL=https://api.viplev.ringhus.dk"
                         + " -e VIPLEV_TOKEN=my-token"
                         + " -e VIPLEV_ENVIRONMENT_ID=" + env.getId()
-                        + " -e AGENT_PROC_PATH=/host/proc"
-                        + " -p 8080:8080"
+                        + " -e VIPLEV_CADVISOR_IMAGE=gcr.io/cadvisor/cadvisor:v0.51.0"
+                        + " -e VIPLEV_NODE_EXPORTER_IMAGE=prom/node-exporter:v1.9.0"
+                        + " -e VIPLEV_K6_IMAGE=grafana/k6:0.53.0"
+                        + " -e VIPLEV_K6_TIMEOUT_MS=300000"
+                        + " -e AGENT_MESSAGE_POLLING_ENABLED=false"
+                        + " -v /var/run/docker.sock:/var/run/docker.sock"
                         + " ghcr.io/viplev/agent:latest");
     }
 


### PR DESCRIPTION
## Summary
- Updates the agent `docker run` command returned when reading an environment to match the new runtime requirements.
- Ensures containers always pull the latest image and restart automatically.
- Closes #49.

## Changes
- Added `--pull always` and `--restart unless-stopped` to the returned Docker command.
- Added env vars: `VIPLEV_CADVISOR_IMAGE`, `VIPLEV_NODE_EXPORTER_IMAGE`, `VIPLEV_K6_IMAGE`, `VIPLEV_K6_TIMEOUT_MS`, `AGENT_MESSAGE_POLLING_ENABLED`.
- Removed deprecated mounts (`/proc`, `/etc/machine-id`), removed `AGENT_PROC_PATH`, and removed `-p 8080:8080`.
- Updated test expectations in `EnvironmentServiceImplTest` and `EnvironmentApiDelegateImplIT` to the new command format.

## Validation
- Updated integration and service-level test assertions for the generated command.
- Verified branch contains commit `0235f2f` with all related mapper and test updates.

## Risks
- Existing consumers that parse or depend on the previous command format may need to adjust.
- Runtime behavior now depends on the newly introduced image/env configuration values being set correctly.